### PR TITLE
Add 'Add to favourites' button to file favouriters popup (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/file-search/file-search.component.html
+++ b/maxhanna.client/src/app/file-search/file-search.component.html
@@ -1,4 +1,4 @@
-﻿<div class="fileActionCommands" *ngIf="!fileSearchMode">
+<div class="fileActionCommands" *ngIf="!fileSearchMode">
   <span [class]="topSearchButtonClass" [style.right]="(searchButtonSlot * 50) + (searchButtonSlot * 3) + 'px'"
     (click)="openSearchPanel();" title="Search for Files"></span>
 </div>
@@ -937,6 +937,19 @@
       <app-user-tag [user]="viewer" [inputtedParentRef]="parentRef ?? inputtedParentRef" [displayHoverPicture]="true"
         [displayMiniTag]="true"></app-user-tag>
     </div>
+  </div>
+  <div class="popupPanelActions" style="margin-top: 10px;">
+    <button (click)="addToFavourites(optionsFile)" *ngIf="userIsLoggedIn() && optionsFile"
+      [disabled]="isLoading || isAddingToFavourites"
+      [title]="optionsFile?.isFavourited ? ('Remove from favourites') : ('Add to favourites')">
+      <ng-container *ngIf="isAddingToFavourites">
+        <app-loading-spinner fontSize="small" label="Saving" emoji="❤️"></app-loading-spinner>
+      </ng-container>
+      <ng-container *ngIf="!isAddingToFavourites">
+        <span *ngIf="!optionsFile?.isFavourited">❤️ Add To Favourites</span>
+        <span *ngIf="optionsFile?.isFavourited">🧡 Remove From Favourites</span>
+      </ng-container>
+    </button>
   </div>
   <button id="closeOverlay" (click)="closeFileFavouriters()">Close</button>
 </div>


### PR DESCRIPTION
## Summary

This PR adds an 'Add to favourites' button to the file favouriters popup in the FileSearch component. The button allows users to easily toggle the favourite status of a file directly from the list of users who have favourited it.

### Changes Made

- Added an 'Add to favourites' button to the file favouriters popup (maxhanna.client/src/app/file-search/file-search.component.html)
- The button appears only when a user is logged in and a file is being viewed
- Uses the existing ddToFavourites() method to maintain consistency with the main file options popup
- Includes appropriate loading indicators and user feedback
- Follows the same design pattern as other favourite-related buttons in the application

### Why These Changes

This enhancement improves user experience by providing a more direct way to manage favourites. Previously, users had to click on the file options panel to add or remove a file from favourites. Now they can do so directly from the list of users who have favourited the file, making the workflow more efficient.

This PR was written using [Vibe Kanban](https://vibekanban.com)