### PR TITLE
On mobile, the calendar component should take up the entire page width (currently smooshed a little (vibe-kanban)

### DIFF
--- a/maxhanna.client/src/app/calendar/calendar.component.css
+++ b/maxhanna.client/src/app/calendar/calendar.component.css
@@ -4,7 +4,7 @@
 
 @media only screen and (max-device-width:800px) {
   .componentMain {
-    max-width: 90vw !important;
+    max-width: 100vw !important;
   }
 }
 


### PR DESCRIPTION
like 80% of the windows width)