### PR TITLE
Remove unnecessary stats rows from crawler component nerd stats display (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/crawler/crawler.component.html
+++ b/maxhanna.client/src/app/crawler/crawler.component.html
@@ -146,42 +146,17 @@
     </div>
   </div>
   <div *ngIf="!isLoading && storageStats" class="optionsStatsWrapperDiv">
-    <div class="optionsStatsDiv">
-      <div class="optionsStatsHeader">Avg. Row Size Bytes:</div>
-      <div class="optionsStatsDescription">
-        {{storageStats.avgRowSizeBytes}}
-      </div>
-    </div>
-    <div class="optionsStatsDiv">
-      <div class="optionsStatsHeader">Avg. Row Size MBytes:</div>
-      <div class="optionsStatsDescription">
-        {{storageStats.avgRowSizeMB}}
-      </div>
-    </div>
+
+
     <div class="optionsStatsDiv">
       <div class="optionsStatsHeader">Total Rows:</div>
       <div class="optionsStatsDescription">
         {{storageStats.totalRows}}
       </div>
     </div>
-    <div class="optionsStatsDiv">
-      <div class="optionsStatsHeader">Days of Data:</div>
-      <div class="optionsStatsDescription">
-        {{storageStats.daysOfData}}
-      </div>
-    </div>
-    <div class="optionsStatsDiv">
-      <div class="optionsStatsHeader">Avg. Rows per Day:</div>
-      <div class="optionsStatsDescription">
-        {{storageStats.avgRowsPerDay}}
-      </div>
-    </div>
-    <div class="optionsStatsDiv">
-      <div class="optionsStatsHeader">Projected Monthly MB usage:</div>
-      <div class="optionsStatsDescription">
-        {{storageStats.projectedMonthlyUsageMB.toFixed(2)}}
-      </div>
-    </div>
+
+
+
     <div class="optionsStatsDiv">
       <div class="optionsStatsHeader">Total Database Size MB:</div>
       <div class="optionsStatsDescription">


### PR DESCRIPTION
This PR removes the following unnecessary rows from the crawler component's nerd stats display:

- Avg. Row Size Bytes:
- Avg. Row Size MBytes:
- Days of Data:
- Avg. Rows per Day:
- Projected Monthly MB usage:

These rows were removed to simplify the nerd stats display and focus on the most relevant information for users.

This PR was written using [Vibe Kanban](https://vibekanban.com)