### PR TITLE
Display anniversary events with years since creation (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/calendar/calendar.component.html
+++ b/maxhanna.client/src/app/calendar/calendar.component.html
@@ -89,7 +89,7 @@
       <tr *ngFor="let cal of selectedCalendarEntries" id="calNo{{cal.id}}" [class]="isEditingEntry.includes(cal) ? 'popupPanel' : ''" (click)="isEditingEntry.includes(cal) ? '' : editCalendarEntry(cal)">
         <td style="width:70px;">{{cal.date | date:'shortTime'}}</td>
         <td>
-          <div *ngIf="!isEditingEntry.includes(cal)">{{ cal.type !== "Milestone" ? cal.note : (cal.date ? '(' + cal.date.toString().substring(0, cal.date.toString().indexOf('-')) + ') ' + cal.note : cal.note) }}</div>
+          <div *ngIf="!isEditingEntry.includes(cal)">{{ cal.type !== "Milestone" && cal.type !== "Anniversary" ? cal.note : (cal.type === "Anniversary" ? formatAnniversaryDisplay(cal) : (cal.date ? '(' + cal.date.toString().substring(0, cal.date.toString().indexOf('-')) + ') ' + cal.note : cal.note)) }}</div>
           <div *ngIf="isEditingEntry.includes(cal)">
             Time: <input id="calendarEditingTime" type="time" [value]="(cal.date | date:'HH:mm')" (input)="hasEditedCalendarEntry = true" />
             <div>Note: <input id="calendarEditingNote" type="text" [value]="cal.note" (input)="hasEditedCalendarEntry = true" /></div>

--- a/maxhanna.client/src/app/calendar/calendar.component.ts
+++ b/maxhanna.client/src/app/calendar/calendar.component.ts
@@ -417,7 +417,53 @@ export class CalendarComponent extends ChildComponent implements OnInit {
   }
 
   convertSymbols(symbols: string[] | undefined): string {
-    return symbols ? symbols.map(symbol => this.eventSymbolMap[symbol] || symbol).join('') : '';
+    if (!symbols) return '';
+    
+    // Process anniversary symbols to show years since creation
+    const processedSymbols = symbols.map(symbol => {
+      if (symbol.toLowerCase() === 'anniversary') {
+        // This is a placeholder - we'll need to get the actual anniversary date to calculate years
+        return symbol; // For now just return the symbol, calculation will be done elsewhere
+      }
+      return this.eventSymbolMap[symbol] || symbol;
+    }).join('');
+    
+    return processedSymbols;
+  }
+  
+  getAnniversaryYears(date: Date | string): number {
+    if (!date) return 0;
+    
+    const eventDate = new Date(date);
+    const currentDate = new Date();
+    
+    // Handle invalid dates
+    if (isNaN(eventDate.getTime())) return 0;
+    
+    // Calculate difference in years
+    let years = currentDate.getFullYear() - eventDate.getFullYear();
+    
+    // Adjust if the birthday hasn't occurred this year yet
+    if (currentDate.getMonth() < eventDate.getMonth() || 
+        (currentDate.getMonth() === eventDate.getMonth() && currentDate.getDate() < eventDate.getDate())) {
+      years--;
+    }
+    
+    // Make sure we don't return negative years
+    return Math.max(0, years);
+  }
+  
+  formatAnniversaryDisplay(entry: CalendarEntry): string {
+    if (!entry || !entry.type || !entry.date) return entry.note || '';
+    
+    const type = entry.type.toLowerCase();
+    
+    if (type === 'anniversary') {
+      const years = this.getAnniversaryYears(entry.date);
+      return `Anniversary (${years} years)`;
+    }
+    
+    return entry.note || '';
   }
   getEventTypes(): string[] {
     return Object.keys(this.eventSymbolMap);


### PR DESCRIPTION
This PR implements the feature to display anniversary events with the number of years since creation. 

Changes made:
- Added calculation logic to determine years between anniversary event date and current date
- Modified display formatting to show 'Anniversary (X years)' format for anniversary events
- Updated calendar component to handle anniversary event formatting
- Maintained backward compatibility for other event types (milestones, birthdays, etc.)

The implementation calculates the number of complete years between the event date and current date, handling edge cases where the anniversary hasn't occurred yet this year.

This PR was written using [Vibe Kanban](https://vibekanban.com)