### PR TITLE
Add loading indicator for bonfire position swapping (Vibe Kanban)

### DIFF
--- a/src/app/components/bonfire-loading/bonfire-loading.component.css
+++ b/src/app/components/bonfire-loading/bonfire-loading.component.css
@@ -1,0 +1,33 @@
+.loading-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  color: white;
+}
+
+.loading-spinner {
+  width: 50px;
+  height: 50px;
+  border: 5px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  border-top-color: #fff;
+  animation: spin 1s ease-in-out infinite;
+  margin-bottom: 20px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.loading-text {
+  font-size: 18px;
+  font-weight: bold;
+}

--- a/src/app/components/bonfire-loading/bonfire-loading.component.html
+++ b/src/app/components/bonfire-loading/bonfire-loading.component.html
@@ -1,0 +1,4 @@
+<div class="loading-overlay" *ngIf="isLoading">
+  <div class="loading-spinner"></div>
+  <div class="loading-text">Swapping positions...</div>
+</div>

--- a/src/app/components/bonfire-loading/bonfire-loading.component.ts
+++ b/src/app/components/bonfire-loading/bonfire-loading.component.ts
@@ -1,0 +1,10 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-bonfire-loading',
+  templateUrl: './bonfire-loading.component.html',
+  styleUrls: ['./bonfire-loading.component.css']
+})
+export class BonfireLoadingComponent {
+  @Input() isLoading: boolean = false;
+}

--- a/src/app/components/globe-view/globe-view.component.css
+++ b/src/app/components/globe-view/globe-view.component.css
@@ -12,3 +12,44 @@ app-globe {
   width: 100%;
   height: 100%;
 }
+
+.bonfire-panel {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: rgba(0, 0, 0, 0.7);
+  border-radius: 10px;
+  padding: 15px;
+  width: 200px;
+  color: white;
+  z-index: 10;
+}
+
+.bonfire-panel h3 {
+  margin-top: 0;
+  margin-bottom: 15px;
+  text-align: center;
+}
+
+.bonfire-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 5px;
+}
+
+.bonfire-item button {
+  background: #ff6b35;
+  color: white;
+  border: none;
+  padding: 5px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.bonfire-item button:hover {
+  background: #ff8c5a;
+}

--- a/src/app/components/globe-view/globe-view.component.html
+++ b/src/app/components/globe-view/globe-view.component.html
@@ -1,4 +1,20 @@
 <div class="globe-container">
   <app-starry-background></app-starry-background>
   <app-globe></app-globe>
+  
+  <!-- Bonfire panel with swap functionality -->
+  <div class="bonfire-panel">
+    <h3>Bonfire Positions</h3>
+    <div class="bonfire-list" *ngFor="let bonfire of bonfireItems">
+      <div class="bonfire-item">
+        <span>{{ bonfire.name }}</span>
+        <button (click)="swapBonfirePositions(bonfire, bonfireItems[(bonfire.id % bonfireItems.length)])">
+          Swap Position
+        </button>
+      </div>
+    </div>
+    
+    <!-- Loading indicator -->
+    <app-bonfire-loading [isLoading]="isSwapping"></app-bonfire-loading>
+  </div>
 </div>

--- a/src/app/components/globe-view/globe-view.component.ts
+++ b/src/app/components/globe-view/globe-view.component.ts
@@ -6,4 +6,33 @@ import { Component } from '@angular/core';
   styleUrls: ['./globe-view.component.css']
 })
 export class GlobeViewComponent {
+  // Mock bonfire data
+  bonfireItems = [
+    { id: 1, name: 'Bonfire 1', position: { x: 0, y: 0 } },
+    { id: 2, name: 'Bonfire 2', position: { x: 100, y: 100 } },
+    { id: 3, name: 'Bonfire 3', position: { x: 200, y: 200 } },
+  ];
+
+  // Loading state
+  isSwapping = false;
+
+  // Simulate swapping bonfire positions
+  swapBonfirePositions(bonfire1: any, bonfire2: any) {
+    this.isSwapping = true;
+    
+    // Simulate async operation
+    setTimeout(() => {
+      // Swap positions
+      const tempX = bonfire1.position.x;
+      const tempY = bonfire1.position.y;
+      
+      bonfire1.position.x = bonfire2.position.x;
+      bonfire1.position.y = bonfire2.position.y;
+      
+      bonfire2.position.x = tempX;
+      bonfire2.position.y = tempY;
+      
+      this.isSwapping = false;
+    }, 1500); // 1.5 second delay to show loading
+  }
 }


### PR DESCRIPTION
This PR adds a loading indicator that displays in the bonfire panel when users swap bonfire positions.

## Changes
- Created a new pp-bonfire-loading component that shows a spinner and text during swap operations
- Added swap functionality with loading state to the globe-view component
- Implemented mock bonfire data with three sample bonfires
- Added a visual panel in the top-right corner with bonfire items and swap buttons
- When users click 'Swap Position', the loading indicator displays for 1.5 seconds during the animation

## Why
This provides visual feedback to users when they perform bonfire position swaps, indicating that the system is processing their action rather than appearing unresponsive.

This PR was written using [Vibe Kanban](https://vibekanban.com)