### PR TITLE
Fix archer arrows moving 30x too fast due to leftover *60f multiplier (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Controllers/DigCraftController.cs
+++ b/maxhanna.Server/Controllers/DigCraftController.cs
@@ -2710,12 +2710,12 @@ var mobSpeed = t switch
                                     if (arrow.Hit) { arrowIdsToRemove.Add(arrow.Id); continue; }
 
                                     // Gravity compensation
-                                    arrow.Vy -= arrow.GravityCompensation * tickSec * 60f;
+                                    arrow.Vy -= arrow.GravityCompensation * tickSec;
 
                                     // Move arrow
-                                    arrow.PosX += arrow.Vx * tickSec * 60f;
-                                    arrow.PosY += arrow.Vy * tickSec * 60f;
-                                    arrow.PosZ += arrow.Vz * tickSec * 60f;
+                                    arrow.PosX += arrow.Vx * tickSec;
+                                    arrow.PosY += arrow.Vy * tickSec;
+                                    arrow.PosZ += arrow.Vz * tickSec;
 
                                     // Check if arrow hit any player
                                     bool hitPlayer = false;


### PR DESCRIPTION
## Summary

Archer mobs were shooting arrows that immediately disappeared — players could never see them.

## Root Cause

The server mob simulation loop runs at 500ms (`_mobTickMs = 500`), making `tickSec = 0.5`. The arrow position and velocity update lines had a `* 60f` multiplier:

```
arrow.PosX += arrow.Vx * tickSec * 60f;   // 1.5 * 0.5 * 60 = 45 blocks/tick
arrow.Vy  -= GravityCompensation * tickSec * 60f;  // gravity 60x too strong
```

This `* 60f` was a leftover from when the simulation presumably ran at 60fps (where `tickSec * 60f = 1`). With the 500ms tick, `tickSec * 60f = 30`, causing arrows to move **30x faster than intended**. An arrow would cross the full 20-block bow range in under one tick, immediately hit terrain (or go out of bounds), get flagged as `Hit = true`, and be removed from `_worldArrows` before the client could ever receive it via `GetMobs`.

## Changes

- **`DigCraftController.cs:2713-2718`** — Removed the `* 60f` multiplier from gravity compensation and all three arrow position axis updates:
  - `arrow.Vy -= arrow.GravityCompensation * tickSec` (was `* tickSec * 60f`)
  - `arrow.PosX += arrow.Vx * tickSec` (was `* tickSec * 60f`)
  - `arrow.PosY += arrow.Vy * tickSec` (was `* tickSec * 60f`)
  - `arrow.PosZ += arrow.Vz * tickSec` (was `* tickSec * 60f`)

Arrows now travel at their intended speed (~1.5 blocks/sec), survive long enough to be sent to clients, and are rendered by the frontend.

This PR was written using [Vibe Kanban](https://vibekanban.com)
