### PR TITLE
Persist minimized posts and closed comments to localStorage (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/comments/comments.component.ts
+++ b/maxhanna.client/src/app/comments/comments.component.ts
@@ -79,6 +79,7 @@ export class CommentsComponent extends ChildComponent implements OnInit, AfterVi
     if (this.inputtedParentRef) {
       this.parentRef = this.inputtedParentRef;
     }
+    this.loadClosedComments();
     this.clearSubCommentsToggled();
     if (this.depth == 0) {
       this.decryptCommentsRecursively(this.commentList);
@@ -647,6 +648,7 @@ export class CommentsComponent extends ChildComponent implements OnInit, AfterVi
     } else {
       this.closedComments.add(comment.id);
     }
+    this.saveClosedComments();
   }
   get filteredComments(): FileComment[] {
     if (!this.commentList) return [];
@@ -696,6 +698,33 @@ export class CommentsComponent extends ChildComponent implements OnInit, AfterVi
         this.decryptCommentsRecursively(comment.comments);
       }
     });
+  }
+
+  private readonly CLOSED_EXPIRY_DAYS = 10;
+
+  private get closedCommentsKey(): string {
+    return `bughosted_closed_comments_${this.component_id}`;
+  }
+
+  private saveClosedComments(): void {
+    const data = {
+      ids: Array.from(this.closedComments),
+      expiry: Date.now() + this.CLOSED_EXPIRY_DAYS * 24 * 60 * 60 * 1000
+    };
+    try { localStorage.setItem(this.closedCommentsKey, JSON.stringify(data)); } catch { }
+  }
+
+  private loadClosedComments(): void {
+    try {
+      const raw = localStorage.getItem(this.closedCommentsKey);
+      if (!raw) return;
+      const data = JSON.parse(raw);
+      if (Date.now() > data.expiry) {
+        localStorage.removeItem(this.closedCommentsKey);
+        return;
+      }
+      this.closedComments = new Set(data.ids || []);
+    } catch { }
   }
 
   formatCommentMetadata(comment: any): string {

--- a/maxhanna.client/src/app/social/social.component.ts
+++ b/maxhanna.client/src/app/social/social.component.ts
@@ -134,6 +134,8 @@ export class SocialComponent extends ChildComponent implements OnInit, OnDestroy
       });
     }
  
+    this.loadMinimizedStories();
+
     const tmpStoryId = this.storyId;
     const tmpCommentId = this.commentId;
 
@@ -714,7 +716,32 @@ export class SocialComponent extends ChildComponent implements OnInit, OnDestroy
     } else {
       this.minimizedStories.push(storyId); 
     }
+    this.saveMinimizedStories();
     this.cd.detectChanges();
+  }
+
+  private readonly MINIMIZED_KEY = 'bughosted_minimized_stories';
+  private readonly MINIMIZED_EXPIRY_DAYS = 10;
+
+  private saveMinimizedStories(): void {
+    const data = {
+      ids: this.minimizedStories,
+      expiry: Date.now() + this.MINIMIZED_EXPIRY_DAYS * 24 * 60 * 60 * 1000
+    };
+    try { localStorage.setItem(this.MINIMIZED_KEY, JSON.stringify(data)); } catch { }
+  }
+
+  private loadMinimizedStories(): void {
+    try {
+      const raw = localStorage.getItem(this.MINIMIZED_KEY);
+      if (!raw) return;
+      const data = JSON.parse(raw);
+      if (Date.now() > data.expiry) {
+        localStorage.removeItem(this.MINIMIZED_KEY);
+        return;
+      }
+      this.minimizedStories = data.ids || [];
+    } catch { }
   }
 
   isStoryExpanded(storyId: number): boolean {


### PR DESCRIPTION
## Summary

- Added `localStorage` persistence for minimized posts in `social.component.ts` and closed comments in `comments.component.ts`
- State is restored on component initialization and cleaned up after 10 days

## Changes

**social.component.ts:**
- `saveMinimizedStories()` stores the list of minimized story IDs in `localStorage` with a 10-day expiry timestamp
- `loadMinimizedStories()` reads and restores the list on init, automatically removing expired entries
- Called on toggle (`toggleHeaderCollapse`) and on component load (`ngOnInit`)

**comments.component.ts:**
- `saveClosedComments()` stores closed comment IDs (per component/comment section) in `localStorage` with a 10-day expiry
- `loadClosedComments()` reads and restores on init, with auto-expiry cleanup
- Called on toggle (`toggleClosed`) and on component load (`ngOnInit`)

## Details

- The storage key for posts is `bughosted_minimized_stories`; for comments it is `bughosted_closed_comments_{component_id}`, scoping each comment section independently
- Expired entries are automatically purged when read
- Un-minimizing a post or un-closing a comment removes its ID from the stored set, so the cache entry is properly deleted on unhide
- Uses `localStorage` (client-side only, no server round-trips)

This PR was written using [Vibe Kanban](https://vibekanban.com)
