### PR TITLE
Respect user display_profile_location setting when fetching stories (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Controllers/SocialController.cs
+++ b/maxhanna.Server/Controllers/SocialController.cs
@@ -265,7 +265,8 @@ namespace maxhanna.Server.Controllers
 									ELSE FALSE 
 							END AS hidden,
 					COALESCE(c.comments_count, 0) AS comments_count,
-					sm.title, sm.description, sm.image_url, sm.metadata_url
+					sm.title, sm.description, sm.image_url, sm.metadata_url,
+					COALESCE(us.display_profile_location, 1) AS display_profile_location
 				FROM stories AS s 
 				JOIN users AS u ON s.user_id = u.id  
 				LEFT JOIN user_display_pictures AS udp ON udp.user_id = u.id 
@@ -275,6 +276,7 @@ namespace maxhanna.Server.Controllers
 					ON s.id = c.story_id
 				LEFT JOIN story_metadata AS sm ON s.id = sm.story_id  
 					LEFT JOIN hidden_stories hs ON hs.story_id = s.id AND hs.user_id = @userId  
+				LEFT JOIN user_settings AS us ON us.user_id = s.user_id
 				{whereClause}  
     			{orderByClause} 
 				LIMIT @pageSize OFFSET @offset;";
@@ -346,8 +348,8 @@ namespace maxhanna.Server.Controllers
                   User = new User(rdr.GetInt32("user_id"), rdr.GetString("username"), null, dpFileEntry, null, null, null),
                   StoryText = rdr.GetString("story_text"),
                   Date = rdr.GetDateTime("date"),
-                  City = rdr.IsDBNull(rdr.GetOrdinal("city")) ? null : rdr.GetString("city"),
-                  Country = rdr.IsDBNull(rdr.GetOrdinal("country")) ? null : rdr.GetString("country"),
+                  City = rdr.GetBoolean("display_profile_location") ? (rdr.IsDBNull(rdr.GetOrdinal("city")) ? null : rdr.GetString("city")) : "Unknown",
+                  Country = rdr.GetBoolean("display_profile_location") ? (rdr.IsDBNull(rdr.GetOrdinal("country")) ? null : rdr.GetString("country")) : "Unknown",
                   CommentsCount = rdr.GetInt32("comments_count"),
                   Metadata = metadata != null ? new List<Metadata>() { metadata } : new List<Metadata>(),
                   StoryFiles = new List<FileEntry>(),


### PR DESCRIPTION
When fetching stories via `GetStories` in `SocialController.cs`, the backend now checks each story author's `display_profile_location` setting from the `user_settings` table.

### Changes
- Added a `LEFT JOIN user_settings` on the story author's `user_id` to the main stories SQL query
- Added `COALESCE(us.display_profile_location, 1)` to the SELECT (defaults to showing location when no row exists)
- When `display_profile_location` is `0` (disabled), the story's `City` and `Country` fields are set to `Unknown` instead of the actual values

### Why
Users who have opted to hide their profile location should not have their location exposed in story posts. This change ensures the privacy setting is respected across the social feed.

### Implementation details
- The join uses `LEFT JOIN` so users without a `user_settings` row still show their location (backwards compatible)
- `COALESCE` defaults to `1` (show) when no settings row exists, preserving existing behavior
- The check uses `rdr.GetBoolean(display_profile_location)` which handles the tinyint(1) MySQL column correctly

This PR was written using [Vibe Kanban](https://vibekanban.com)