### PR TITLE
fix: archer arrows missing players due to hitbox and gravity mismatch (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Controllers/DigCraftController.cs
+++ b/maxhanna.Server/Controllers/DigCraftController.cs
@@ -2736,7 +2736,7 @@ var mobSpeed = t switch
                                     foreach (var pl in players)
                                     {
                                         float pdx = arrow.PosX - pl.x;
-                                        float pdy = arrow.PosY - pl.y;
+                                        float pdy = arrow.PosY - (pl.y + 0.9f);
                                         float pdz = arrow.PosZ - pl.z;
                                         float pDistSq = pdx * pdx + pdy * pdy + pdz * pdz;
                                         if (pDistSq < 1.0f)

--- a/maxhanna.client/src/app/digcraft/digcraft.component.ts
+++ b/maxhanna.client/src/app/digcraft/digcraft.component.ts
@@ -5202,7 +5202,7 @@ export class DigCraftComponent extends ChildComponent implements OnInit, OnDestr
   }
   private updateArrows(): void {
     const now = performance.now();
-    const gravity = 9.8;
+    const serverArrowGravity = 0.03;
 
     // Update server-synced arrows with terrain collision detection
     const nonSolidBlocks = new Set([
@@ -5220,7 +5220,7 @@ export class DigCraftComponent extends ChildComponent implements OnInit, OnDestr
       arrow.wx += arrow.vx * dt;
       arrow.wy += arrow.vy * dt;
       arrow.wz += arrow.vz * dt;
-      arrow.vy -= gravity * dt;
+      arrow.vy -= serverArrowGravity * dt;
       arrow.lastUpdateTime = now;
 
       // Spawn trail particle every ~50ms
@@ -5270,7 +5270,7 @@ export class DigCraftComponent extends ChildComponent implements OnInit, OnDestr
       arrow.wx += arrow.vx * dt;
       arrow.wy += arrow.vy * dt;
       arrow.wz += arrow.vz * dt;
-      arrow.vy -= gravity * dt;
+      arrow.vy -= 9.8 * dt;
       arrow.lastUpdateTime = now;
 
       // Spawn trail particle every ~50ms


### PR DESCRIPTION
﻿## Summary

Fixes three interrelated bugs where archer mob arrows would miss players every time, causing arrows to accumulate indefinitely without dealing damage.

## Changes

### 1. Arrow hit detection centered at player feet instead of body (`DigCraftController.cs`)

The archer aims arrows at `player.y + 1.62` (eye level), but hit detection measured distance from `player.y` (feet). Since a player is 1.8 blocks tall, the arrow flies ~1.62 blocks above the hit test center — well outside the 1-block radius sphere. Every arrow missed.

**Fix:** Changed the hit check center from `pl.y` to `pl.y + 0.9f` (player's waist), so the sphere covers the full player hitbox.

### 2. Client gravity 327x stronger than server (`digcraft.component.ts`)

Server applies `Vy -= 0.03 * dt` per tick (gravity compensation). Client was applying `vy -= 9.8 * dt` (Earth gravity). Server-synced arrows on the client would nosedive into the ground and get stuck there, while the server arrow continued flying — causing visual desync and false terrain collision.

**Fix:** Server-synced arrows now use `serverArrowGravity = 0.03` to match the server. Player-fired arrows retain `9.8` for realistic arc.

### 3. Arrow accumulation

Because every arrow missed the player (bug #1), they perpetually accumulated in `_worldArrows` with the archer firing every 1.6s. With hit detection fixed, arrows now register hits and are properly removed.

## Why this happened

The root cause was a disconnect between the archer's aim (player eye level at `y + 1.62`) and the hit test origin (player feet at `y`). Combined with a 327x gravity discrepancy between client and server, arrows would visually dive into the ground while the server reported them flying past the player forever.

This PR was written using [Vibe Kanban](https://vibekanban.com)
