### PR TITLE
Fix mobile canvas interaction for DigCraft by adjusting touch-action properties (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/digcraft/digcraft.component.css
+++ b/maxhanna.client/src/app/digcraft/digcraft.component.css
@@ -51,8 +51,8 @@ button {
   display: block;
   z-index: 6;
   background: transparent;
-  touch-action: none;
-  pointer-events: none;
+  touch-action: auto;
+  pointer-events: auto;
 }
 
 .game-canvas.hidden {


### PR DESCRIPTION
This PR resolves the mobile interaction issue with the DigCraft canvas where users couldn't interact with the game on mobile devices.\n\nChanges made:\n- Updated touch-action property from 'none' to 'auto' on the game canvas element\n- Updated pointer-events property from 'none' to 'auto' on the game canvas element\n\nThese changes allow mobile touch interactions while preserving desktop functionality. The issue was caused by overly restrictive CSS properties that prevented touch events from being processed on mobile devices.\n\nThis PR was written using [Vibe Kanban](https://vibekanban.com)