### PR TITLE
Simplify flight tracking to one-click callsign entry with OpenSky auto-fetch (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/globe/globe.component.css
+++ b/maxhanna.client/src/app/globe/globe.component.css
@@ -329,22 +329,6 @@
   border-color: #4af;
 }
 
-.airport-row {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.airport-input {
-  flex: 1;
-}
-
-.airport-row .arrow {
-  color: #666;
-  font-size: 14px;
-  flex-shrink: 0;
-}
-
 .add-flight-btn {
   padding: 8px 12px;
   border: 1px solid #00ddff;

--- a/maxhanna.client/src/app/globe/globe.component.html
+++ b/maxhanna.client/src/app/globe/globe.component.html
@@ -70,15 +70,9 @@
     <div class="data-content" *ngIf="activeDataTab === 'flights'">
       <div class="flights-content">
         <div class="add-flight-form">
-          <div class="form-title">Add Flight</div>
-          <input type="text" [(ngModel)]="newCallsign" placeholder="Callsign (e.g. ACA123)" class="flight-input">
-          <input type="text" [(ngModel)]="newLabel" placeholder="Label (optional)" class="flight-input">
-          <div class="airport-row">
-            <input type="text" [(ngModel)]="newOrigin" placeholder="Origin (e.g. YYZ)" class="flight-input airport-input">
-            <span class="arrow">→</span>
-            <input type="text" [(ngModel)]="newDest" placeholder="Dest (e.g. LHR)" class="flight-input airport-input">
-          </div>
-          <button type="button" (click)="addFlight()" class="add-flight-btn">✈ Add Flight</button>
+          <div class="form-title">Track Flight</div>
+          <input type="text" [(ngModel)]="newCallsign" placeholder="Callsign (e.g. LXJ269)" class="flight-input" (keyup.enter)="addFlight()">
+          <button type="button" (click)="addFlight()" class="add-flight-btn">✈ Track Flight</button>
         </div>
         <div class="flight-controls">
           <button type="button" (click)="loadFlights()">Refresh Flights</button>
@@ -88,7 +82,7 @@
           <div class="flight-item" *ngFor="let flight of trackedFlights">
             <div class="flight-info">
               <span class="flight-callsign">{{ flight.callsign }}</span>
-              <span class="flight-route">{{ flight.origin || '?' }} → {{ flight.destination || '?' }}</span>
+              <span class="flight-route" *ngIf="flight.origin && flight.destination">{{ flight.origin }} → {{ flight.destination }}</span>
               <span class="flight-altitude">{{ flight.altitude || 'N/A' }} ft</span>
               <span class="flight-heading">{{ flight.heading || 'N/A' }}°</span>
             </div>
@@ -116,14 +110,13 @@
     </div>
     <div class="flight-detail-body">
       <div class="detail-row"><span class="detail-label">Callsign:</span><span>{{ selectedFlight.callsign }}</span></div>
-      <div class="detail-row"><span class="detail-label">Label:</span><span>{{ selectedFlight.label || 'N/A' }}</span></div>
       <div class="detail-row"><span class="detail-label">Latitude:</span><span>{{ selectedFlight.lat?.toFixed(4) || 'N/A' }}</span></div>
       <div class="detail-row"><span class="detail-label">Longitude:</span><span>{{ selectedFlight.lon?.toFixed(4) || 'N/A' }}</span></div>
       <div class="detail-row"><span class="detail-label">Altitude:</span><span>{{ selectedFlight.altitude || 'N/A' }} ft</span></div>
       <div class="detail-row"><span class="detail-label">Heading:</span><span>{{ selectedFlight.heading || 'N/A' }}°</span></div>
       <div class="detail-row"><span class="detail-label">Speed:</span><span>{{ selectedFlight.velocity ? (selectedFlight.velocity * 1.944).toFixed(1) : 'N/A' }} knots</span></div>
-      <div class="detail-row"><span class="detail-label">Origin:</span><span>{{ selectedFlight.origin || 'N/A' }}</span></div>
-      <div class="detail-row"><span class="detail-label">Destination:</span><span>{{ selectedFlight.destination || 'N/A' }}</span></div>
+      <div class="detail-row" *ngIf="selectedFlight.origin"><span class="detail-label">Origin:</span><span>{{ selectedFlight.origin }}</span></div>
+      <div class="detail-row" *ngIf="selectedFlight.destination"><span class="detail-label">Destination:</span><span>{{ selectedFlight.destination }}</span></div>
       <div class="detail-row" *ngIf="selectedFlight.lastUpdated"><span class="detail-label">Updated:</span><span>{{ selectedFlight.lastUpdated | date:'medium' }}</span></div>
     </div>
   </div>

--- a/maxhanna.client/src/app/globe/globe.component.ts
+++ b/maxhanna.client/src/app/globe/globe.component.ts
@@ -1,4 +1,4 @@
-﻿import {
+import {
   Component, OnInit, OnDestroy, AfterViewInit,
   ElementRef, ViewChild, HostListener, NgZone,
   EventEmitter, Input, Output
@@ -188,9 +188,6 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   flightInterval: ReturnType<typeof setInterval> | null = null;
   showDataPanel = false;
   newCallsign = '';
-  newLabel = '';
-  newOrigin = '';
-  newDest = '';
   selectedFlight: any = null;
   showFlightDetail = false;
   flightArcs: Arc[] = [];
@@ -345,30 +342,40 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   addFlight(): void {
     const cs = this.newCallsign.trim().toUpperCase();
     if (!cs) return;
-    const origin = this.newOrigin.trim().toUpperCase();
-    const dest = this.newDest.trim().toUpperCase();
-    const originCoords = origin ? this.flightService.getAirportCoords(origin) : null;
-    const destCoords = dest ? this.flightService.getAirportCoords(dest) : null;
+
+    let lat: number | undefined;
+    let lon: number | undefined;
+    let altitude: number | undefined;
+    let heading: number | undefined;
+    let velocity: number | undefined;
+
+    for (const state of this.allFlightStates) {
+      const scs = state[1]?.trim().toUpperCase();
+      if (scs === cs) {
+        lat = state[6];
+        lon = state[5];
+        altitude = state[7];
+        heading = state[10];
+        velocity = state[9];
+        break;
+      }
+    }
 
     const flight: TrackedFlight = {
       id: `flight_${Date.now()}`,
       callsign: cs,
-      label: this.newLabel.trim() || cs,
-      origin: origin || undefined,
-      destination: dest || undefined,
-      originLat: originCoords?.lat,
-      originLon: originCoords?.lon,
-      destLat: destCoords?.lat,
-      destLon: destCoords?.lon,
+      label: cs,
+      lat,
+      lon,
+      altitude,
+      heading,
+      velocity,
       enabled: true,
     };
 
     this.trackedFlights = [...this.trackedFlights, flight];
     this.flightService.saveTrackedFlights(this.trackedFlights);
     this.newCallsign = '';
-    this.newLabel = '';
-    this.newOrigin = '';
-    this.newDest = '';
 
     if (!this.flightInterval) {
       this.loadFlights();


### PR DESCRIPTION
## Summary

The Add Flight form in the globe flight tracker previously required manually entering origin and destination airport codes, a label, and the callsign. Now it accepts just a callsign (e.g. `LXJ269`) and automatically fetches all position data from the OpenSky Network API.

## Changes

### `globe.component.ts`
- Removed `newLabel`, `newOrigin`, `newDest` component properties — only `newCallsign` remains
- Rewrote `addFlight()` to look up the callsign in the already-loaded OpenSky state data and auto-populate `lat`, `lon`, `altitude`, `heading`, and `velocity`
- The existing 15-second `updateFlightPositions()` interval continues to keep the aircraft marker moving in real time

### `globe.component.html`
- Replaced the multi-field form (callsign, label, origin, destination) with a single callsign input that supports Enter-key submission
- Route display (`origin → destination`) now only renders when both values are present
- Flight detail popup no longer shows a separate Label row; origin/destination rows are conditionally displayed only when available

### `globe.component.css`
- Removed unused `.airport-row`, `.airport-input`, and `.arrow` styles

## Why

Previously, users had to know and type airport IATA codes for origin and destination just to track a live flight on the globe. With OpenSky already providing real-time position data for every active flight, the extra fields were unnecessary friction. A single callsign is sufficient to locate, track, and display the flight.

This PR was written using [Vibe Kanban](https://vibekanban.com)
