### PR TITLE
Add Medical AI mode with camera/upload vision support to HostAI (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/host-ai/host-ai.component.css
+++ b/maxhanna.client/src/app/host-ai/host-ai.component.css
@@ -2,41 +2,141 @@
   min-width: 50vw;
   height: CALC(100vh - 60px);
   height: CALC(100dvh - 60px);
+  display: flex;
+  flex-direction: column;
+}
+
+.ai-mode-bar {
+  display: flex;
+  justify-content: center;
+  gap: 0;
+  padding: 6px 10px;
+  background: var(--component-background-color, #1a1a2e);
+  border-bottom: 1px solid var(--main-border-color, #333);
+  flex-shrink: 0;
+}
+
+.mode-btn {
+  padding: 6px 18px;
+  border: 1px solid var(--main-border-color, #555);
+  background: transparent;
+  color: var(--main-font-color, #ccc);
+  cursor: pointer;
+  font-size: 13px;
+  transition: all 0.2s;
+}
+
+.mode-btn:first-child {
+  border-radius: 6px 0 0 6px;
+}
+
+.mode-btn:last-child {
+  border-radius: 0 6px 6px 0;
+  border-left: none;
+}
+
+.mode-btn.active {
+  background: var(--main-highlight-color, #4a90d9);
+  color: #fff;
+  border-color: var(--main-highlight-color, #4a90d9);
+}
+
+.mode-btn:hover:not(.active) {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.medical-controls {
+  padding: 8px 16px;
+  background: rgba(255, 60, 60, 0.05);
+  border-bottom: 1px solid rgba(255, 60, 60, 0.2);
+  flex-shrink: 0;
+}
+
+.medical-controls-inner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.med-btn {
+  padding: 6px 14px;
+  border: 1px solid var(--main-border-color, #555);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--main-font-color, #ccc);
+  cursor: pointer;
+  font-size: 13px;
+  transition: all 0.2s;
+}
+
+.med-btn:hover:not(:disabled) {
+  background: rgba(255, 60, 60, 0.1);
+  border-color: #ff6b6b;
+}
+
+.med-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.med-hint {
+  font-size: 12px;
+  color: var(--secondary-font-color, #888);
+  font-style: italic;
+}
+
+.image-preview {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 200px;
+}
+
+.image-preview img {
+  max-height: 60px;
+  border-radius: 6px;
+  border: 2px solid var(--main-highlight-color, #4a90d9);
+  object-fit: cover;
+}
+
+.remove-image-btn {
+  padding: 2px 8px;
+  border: none;
+  border-radius: 4px;
+  background: #ff4444;
+  color: #fff;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .chat-container {
-  height: CALC(100vh - 60px);
-  height: CALC(100dvh - 60px);
+  flex: 1;
   display: flex;
   flex-direction: column;
-  flex-wrap: nowrap;
-  justify-content: space-between;
-  align-content: space-around;
-  align-items: stretch;
+  min-height: 0;
 }
 
 
 .chat-container .input-container {
-  flex-grow: 1;
-  /* Let the input container take up available space */
+  flex-shrink: 0;
   display: flex;
   flex-direction: row;
 }
 
 .chat-container .input-container textarea {
   flex-grow: 1;
-  /* Let the textarea expand within the input container */
   min-height: 40px;
-  /* Set a minimum height to prevent it from shrinking too much */
 }
 
 
 .chat-box {
-  height: CALC(100vh - 114px);
-  height: CALC(100dvh - 114px);
+  flex: 1;
   overflow-y: auto;
   padding-left: 30px;
   padding-right: 30px;
+  min-height: 0;
 }
 
 .message {
@@ -132,18 +232,16 @@ ul {
 
 .emptyHostAiMessage {
   font-size: xx-large;
-  height: CALC(100vh - 146px);
-  height: CALC(100dvh - 146px);
+  flex: 1;
   overflow-y: auto;
-  padding-left: 30px;
-  padding-right: 30px;
+  padding: 16px 30px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
   background: linear-gradient(135deg, var(--component-background-color) 5%, var(--main-highlight-color) 95%);
-  padding: 16px;
   text-align: center;
+  min-height: 0;
 }
 
 

--- a/maxhanna.client/src/app/host-ai/host-ai.component.html
+++ b/maxhanna.client/src/app/host-ai/host-ai.component.html
@@ -6,7 +6,29 @@
     (closeClicked)="remove_me('HostAiComponent');">
   </app-title-bar>
 
-  <div class="chat-container" #chatContainer>
+  <div class="ai-mode-bar">
+    <button class="mode-btn" [class.active]="aiMode === 'general'" (click)="switchMode('general')">
+      🤖 General AI
+    </button>
+    <button class="mode-btn" [class.active]="aiMode === 'medical'" (click)="switchMode('medical')">
+      🏥 Medical AI
+    </button>
+  </div>
+
+  <div class="medical-controls" *ngIf="aiMode === 'medical'">
+    <div class="medical-controls-inner">
+      <button class="med-btn" (click)="triggerCamera()" title="Take a photo with your camera" [disabled]="isLoading">📷 Camera</button>
+      <button class="med-btn" (click)="triggerImageUpload()" title="Upload an image" [disabled]="isLoading">🖼️ Upload</button>
+      <div class="image-preview" *ngIf="capturedImage">
+        <img [src]="capturedImage" alt="Medical image" />
+        <button class="remove-image-btn" (click)="removeCapturedImage()">✕ Remove</button>
+      </div>
+      <span class="med-hint" *ngIf="!capturedImage">Take a photo or upload a medical image for AI analysis</span>
+    </div>
+  </div>
+
+  <div class="chat-container" #chatContainer
+    [class.chat-container--with-controls]="aiMode === 'medical'">
     <div class="chat-box" *ngIf="chatMessages && chatMessages.length > 0">
       <div *ngFor="let message of chatMessages; let i = index">
         <div class="hr" *ngIf="i > 0"></div>
@@ -44,7 +66,7 @@
         [takeAllSpace]="true" [user]="parentRef?.user" [inputtedParentRef]="parentRef" [maxSelectedFiles]="1"
         (selectFileEvent)="selectFile($event)">
       </app-media-selector>
-      <button (click)="sendMessage()" [disabled]="isLoading || (!userMessage.trim() && !selectedFile)">Send</button>
+      <button (click)="sendMessage()" [disabled]="isLoading || !canSend">Send</button>
     </div>
   </div>
 </div>

--- a/maxhanna.client/src/app/host-ai/host-ai.component.ts
+++ b/maxhanna.client/src/app/host-ai/host-ai.component.ts
@@ -1,7 +1,6 @@
 import { Component, ViewChild, ElementRef, OnDestroy, ChangeDetectorRef } from '@angular/core';
 import { AiService } from '../../services/ai.service';
 import { ChildComponent } from '../child.component';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { User } from '../../services/datacontracts/user/user';
 import { SpeechRecognitionComponent } from '../speech-recognition/speech-recognition.component';
 import { FileEntry } from '../../services/datacontracts/file/file-entry';
@@ -27,6 +26,19 @@ export class HostAiComponent extends ChildComponent implements OnDestroy {
   chatMessages: AIMessage[] = [];
   hostName: string = "Host";
 
+  aiMode: 'general' | 'medical' = 'general';
+  capturedImage: string | null = null;
+  medicalChatHistory: { role: string; content: any }[] = [];
+  private ollamaBaseUrl = 'http://192.168.2.58:11434/v1';
+  private medicalModel = 'medgemma:4b';
+
+  get canSend(): boolean {
+    if (this.aiMode === 'medical') {
+      return !!this.userMessage.trim() || !!this.capturedImage;
+    }
+    return !!this.userMessage.trim() || !!this.selectedFile;
+  }
+
   responseLength? = 200;
   isMenuOpen = false;
   startedTalking = false;
@@ -40,7 +52,98 @@ export class HostAiComponent extends ChildComponent implements OnDestroy {
   @ViewChild('chatContainer') chatContainer!: ElementRef<HTMLDivElement>;
   @ViewChild(SpeechRecognitionComponent) speechRecognitionComponent?: SpeechRecognitionComponent;
   @ViewChild(MediaSelectorComponent) fileSelector?: MediaSelectorComponent;
- 
+
+  switchMode(mode: 'general' | 'medical') {
+    this.aiMode = mode;
+    this.hostName = mode === 'medical' ? 'Medical AI' : 'Host';
+    this.capturedImage = null;
+  }
+
+  triggerCamera() {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.capture = 'environment';
+    input.onchange = (e) => this.handleImageInput(e);
+    input.click();
+  }
+
+  triggerImageUpload() {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'image/*';
+    input.onchange = (e) => this.handleImageInput(e);
+    input.click();
+  }
+
+  handleImageInput(event: any) {
+    const file = event.target?.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      this.capturedImage = e.target?.result as string;
+      this.cdr.detectChanges();
+    };
+    reader.readAsDataURL(file);
+  }
+
+  removeCapturedImage() {
+    this.capturedImage = null;
+  }
+
+  async sendMedicalMessage() {
+    if (!this.parentRef) return alert("No parent ref?");
+    const userText = this.userMessage.trim();
+    if (!userText && !this.capturedImage) return;
+
+    this.startLoading();
+    this.pushMessage({ sender: 'You', message: userText ? userText + (this.capturedImage ? ' 📷' : '') : '📷 Medical image' });
+
+    const content: any[] = [{ type: 'text', text: userText || 'Analyze this medical image' }];
+    if (this.capturedImage) {
+      content.push({ type: 'image_url', image_url: { url: this.capturedImage } });
+    }
+
+    const messages = [
+      ...this.medicalChatHistory.slice(-20),
+      { role: 'user', content }
+    ];
+
+    try {
+      const response = await fetch(`${this.ollamaBaseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          model: this.medicalModel,
+          messages: messages,
+          stream: false
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error(`Ollama returned ${response.status}`);
+      }
+
+      const data = await response.json();
+      const reply = data.choices?.[0]?.message?.content || 'No response from medical AI';
+      const parsedReply = this.aiService.parseMessage(reply);
+
+      this.medicalChatHistory.push({ role: 'user', content });
+      this.medicalChatHistory.push({ role: 'assistant', content: reply });
+
+      this.pushMessage({ sender: this.hostName, message: parsedReply });
+      this.capturedImage = null;
+      this.chatInput.nativeElement.value = '';
+      this.userMessage = '';
+    } catch (error) {
+      console.error('Medical AI error:', error);
+      this.parentRef.showNotification('Medical AI unavailable. Is Ollama running on port 11434?');
+      this.pushMessage({ sender: 'System', message: 'Failed to reach Medical AI. Make sure Ollama is running at ' + this.ollamaBaseUrl + ' and CORS is configured (OLLAMA_ORIGINS=*).' });
+    }
+
+    this.stopLoading();
+  }
+
   ngOnDestroy() { 
     if (this.speechRecognitionComponent) {
       this.speechRecognitionComponent.stopListening();
@@ -52,8 +155,14 @@ export class HostAiComponent extends ChildComponent implements OnDestroy {
 
   sendMessage() {
     if (!this.parentRef) return alert("No parent ref?");
-    const user = this.parentRef.user ?? new User(0);
     this.userMessage = this.chatInput.nativeElement.value.trim();
+
+    if (this.aiMode === 'medical') {
+      this.sendMedicalMessage();
+      return;
+    }
+
+    const user = this.parentRef.user ?? new User(0);
 
     if (!this.userMessage.trim() && !this.selectedFile) return alert("No message sent");
 


### PR DESCRIPTION
## Summary

Adds a **Medical AI mode** toggle to the HostAI component, enabling users to switch between General AI and a medical-dedicated AI powered by an Ollama server (`medgemma:4b`). Medical mode supports camera capture, image upload, and vision-based chat for health information queries.

## Changes

### AI Mode Toggle
- New segmented toggle bar at the top of HostAI switches between **General AI** and **Medical AI**
- Toggle changes the title bar label ("Host" vs "Medical AI") and routes messages to the appropriate backend

### Medical AI Provider
- Direct client-side `fetch` to Ollama's OpenAI-compatible endpoint at `http://192.168.2.58:11434/v1/chat/completions`
- Uses `medgemma:4b` model with full vision support via OpenAI-format content parts (`text` + `image_url`)
- Maintains its own conversation history (last 20 messages) for medical context
- Separated from the existing server-side AI pipeline - no server changes needed

### Camera and Image Upload (Medical Vision)
- **Camera button** - opens device camera (`<input capture="environment">`) on mobile/desktop
- **Upload button** - standard file picker for selecting medical images
- Selected image shown as a thumbnail preview with a Remove button
- Image encoded as base64 data URL and sent alongside the user's text prompt to the vision model

### Layout Refactor
- Converted chat area from hardcoded `CALC()` heights to a flexbox layout so it adapts dynamically when medical controls are shown/hidden
- All three main files (TS, HTML, CSS) were modified

## Setup Required
- Ollama running at `192.168.2.58:11434` with CORS enabled (`OLLAMA_ORIGINS=*`)
- Model pulled: `ollama pull medgemma:4b`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)
