### PR TITLE
Proxy medical AI Ollama calls through backend to hide internal IP (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Controllers/AiController.cs
+++ b/maxhanna.Server/Controllers/AiController.cs
@@ -186,6 +186,52 @@ namespace maxhanna.Server.Controllers
       }
     }
 
+    [HttpPost("/Ai/MedicalChat", Name = "MedicalChat")]
+    public async Task<IActionResult> MedicalChat([FromBody] JsonElement requestBody)
+    {
+      try
+      {
+        var ollamaBaseUrl = _config.GetValue<string>("Ai:MedicalBaseUrl") ?? "http://192.168.2.58:11434/v1";
+        var medicalModel = _config.GetValue<string>("Ai:MedicalModel") ?? "medgemma:4b";
+
+        var messages = requestBody.GetProperty("messages");
+
+        var payload = new
+        {
+          model = medicalModel,
+          messages = messages,
+          stream = false
+        };
+
+        var jsonContent = new StringContent(
+          JsonSerializer.Serialize(payload),
+          Encoding.UTF8,
+          "application/json"
+        );
+
+        using var httpReq = new HttpRequestMessage(HttpMethod.Post, $"{ollamaBaseUrl}/chat/completions")
+        {
+          Content = jsonContent
+        };
+
+        var response = await _httpClient.SendAsync(httpReq);
+        var respBody = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+        {
+          _ = _log.Db($"Medical AI error {(int)response.StatusCode}: {respBody}", null, "AiController", true);
+          return StatusCode((int)response.StatusCode, new { error = "Medical AI unavailable" });
+        }
+
+        return Content(respBody, "application/json");
+      }
+      catch (Exception ex)
+      {
+        _ = _log.Db($"Error in MedicalChat: {ex.Message}", null, "AiController", true);
+        return StatusCode(500, new { error = "Medical AI unavailable" });
+      }
+    }
+
     [HttpPost("/Ai/GetMarketSentiment", Name = "GetMarketSentiment")]
     public async Task<IActionResult> GetMarketSentiment([FromBody] MarketSentimentRequest request)
     {

--- a/maxhanna.client/src/app/host-ai/host-ai.component.ts
+++ b/maxhanna.client/src/app/host-ai/host-ai.component.ts
@@ -29,8 +29,6 @@ export class HostAiComponent extends ChildComponent implements OnDestroy {
   aiMode: 'general' | 'medical' = 'general';
   capturedImage: string | null = null;
   medicalChatHistory: { role: string; content: any }[] = [];
-  private ollamaBaseUrl = 'http://192.168.2.58:11434/v1';
-  private medicalModel = 'medgemma:4b';
 
   get canSend(): boolean {
     if (this.aiMode === 'medical') {
@@ -110,18 +108,14 @@ export class HostAiComponent extends ChildComponent implements OnDestroy {
     ];
 
     try {
-      const response = await fetch(`${this.ollamaBaseUrl}/chat/completions`, {
+      const response = await fetch('/ai/medicalchat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          model: this.medicalModel,
-          messages: messages,
-          stream: false
-        })
+        body: JSON.stringify({ messages })
       });
 
       if (!response.ok) {
-        throw new Error(`Ollama returned ${response.status}`);
+        throw new Error(`Medical AI returned ${response.status}`);
       }
 
       const data = await response.json();
@@ -137,8 +131,8 @@ export class HostAiComponent extends ChildComponent implements OnDestroy {
       this.userMessage = '';
     } catch (error) {
       console.error('Medical AI error:', error);
-      this.parentRef.showNotification('Medical AI unavailable. Is Ollama running on port 11434?');
-      this.pushMessage({ sender: 'System', message: 'Failed to reach Medical AI. Make sure Ollama is running at ' + this.ollamaBaseUrl + ' and CORS is configured (OLLAMA_ORIGINS=*).' });
+      this.parentRef.showNotification('Medical AI unavailable.');
+      this.pushMessage({ sender: 'System', message: 'Failed to reach Medical AI.' });
     }
 
     this.stopLoading();


### PR DESCRIPTION
## Summary

Moves the Ollama API call for medical AI from the frontend (where it exposed an internal IP address) to the backend, preventing clients from seeing `192.168.2.58`.

## Changes

- **Backend (`AiController.cs`)**: Added a new `POST /Ai/MedicalChat` endpoint that accepts OpenAI-format messages, constructs the payload with the server-configured model (`medgemma:4b`), and forwards the request to `http://192.168.2.58:11434/v1/chat/completions`. The Ollama base URL and model are configurable via `Ai:MedicalBaseUrl` and `Ai:MedicalModel` in appsettings.

- **Frontend (`host-ai.component.ts`)**: Removed the hardcoded `ollamaBaseUrl` and `medicalModel` fields. The `sendMedicalMessage()` method now calls `/ai/medicalchat` instead of directly fetching the Ollama server. Error messages no longer leak the internal IP.

## Why

The internal IP `192.168.2.58` was previously hardcoded in the frontend TypeScript, meaning every client could see and directly access the Ollama server. Since only the server can reach that IP, all medical AI requests must be proxied through the backend.

This PR was written using [Vibe Kanban](https://vibekanban.com)
