### PR TITLE
fix(globe): proxy OpenSky API through backend, auto-load flights, fix interval leak (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Controllers/FlightController.cs
+++ b/maxhanna.Server/Controllers/FlightController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+
+namespace maxhanna.Server.Controllers
+{
+	[ApiController]
+	[Route("[controller]")]
+	public class FlightController : ControllerBase
+	{
+		private readonly IHttpClientFactory _httpClientFactory;
+		private static List<object> _cachedStates = new List<object>();
+		private static DateTime _lastFetch = DateTime.MinValue;
+		private static readonly TimeSpan CacheDuration = TimeSpan.FromSeconds(15);
+
+		public FlightController(IHttpClientFactory httpClientFactory)
+		{
+			_httpClientFactory = httpClientFactory;
+		}
+
+		[HttpGet("states")]
+		public async Task<IActionResult> GetStates()
+		{
+			if (DateTime.UtcNow - _lastFetch < CacheDuration && _cachedStates.Count > 0)
+			{
+				return Ok(new { states = _cachedStates });
+			}
+
+			try
+			{
+				var client = _httpClientFactory.CreateClient();
+				var response = await client.GetAsync("https://opensky-network.org/api/states/all");
+				if (response.IsSuccessStatusCode)
+				{
+					var json = await response.Content.ReadAsStringAsync();
+					var data = JsonConvert.DeserializeAnonymousType(json, new { states = new List<object>() });
+					if (data?.states != null)
+					{
+						_cachedStates = data.states;
+						_lastFetch = DateTime.UtcNow;
+					}
+				}
+			}
+			catch { }
+
+			return Ok(new { states = _cachedStates });
+		}
+	}
+}

--- a/maxhanna.client/src/app/globe/globe.component.ts
+++ b/maxhanna.client/src/app/globe/globe.component.ts
@@ -274,7 +274,11 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   // =========================================================================
   ngOnInit(): void {
     this.loadStories();
-    this.loadNewsPins(); 
+    this.loadNewsPins();
+    const saved = this.flightService.getTrackedFlights();
+    if (saved.length > 0) {
+      this.loadFlights();
+    }
   }
 
   ngAfterViewInit(): void {
@@ -290,6 +294,10 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     this.destroyed = true;
     this.stopPingTour();
     cancelAnimationFrame(this.rafId);
+    if (this.flightInterval) {
+      clearInterval(this.flightInterval);
+      this.flightInterval = null;
+    }
   }
 
   // =========================================================================

--- a/maxhanna.client/src/proxy.conf.js
+++ b/maxhanna.client/src/proxy.conf.js
@@ -67,7 +67,8 @@ const PROXY_CONFIG = [
       "/bones",
       "/ratings",
       "/digcraft",
-      "/tilecache"
+      "/tilecache",
+      "/flight"
     ],
     target,
     changeOrigin: true, // This helps with certain CORS issues and forwards headers correctly 

--- a/maxhanna.client/src/services/flight.service.ts
+++ b/maxhanna.client/src/services/flight.service.ts
@@ -114,9 +114,9 @@ export class FlightService {
 
   private async fetchStates(): Promise<any[]> {
     try {
-      const res = await fetch('https://opensky-network.org/api/states/all');
+      const res = await fetch('/flight/states');
       if (!res.ok) {
-        console.warn('OpenSky API returned', res.status);
+        console.warn('Flight API returned', res.status);
         return this.cachedStates;
       }
       const data = await res.json();


### PR DESCRIPTION
﻿## Summary

Fixes tracked flights not updating on the globe by proxying the OpenSky API through the .NET backend to avoid anonymous rate limits, and improves the flight tracking UX with auto-load on init and proper cleanup.

## Changes

### Bug Fixes
- **OpenSky API 429 rate limiting**: The frontend was calling https://opensky-network.org/api/states/all directly from the browser. Anonymous rate limits (~4000 req/day) were exhausted within hours due to 15s polling (~5760 req/day). A new backend controller (FlightController.cs) proxies these requests with server-side caching (15s TTL), so multiple browser tabs share one cache and the server IP gets a separate rate-limit budget.
- **Memory leak in ngOnDestroy**: flightInterval was never cleared when the globe component was destroyed, causing the polling interval to keep running.

### UX Improvements
- **Auto-load tracked flights on init**: If tracked flights exist in localStorage, the globe now automatically starts fetching and displaying them on page load — no more needing to manually click "Start Tracking" after every refresh.

### Configuration
- Added /flight to the Angular dev server proxy config so requests route to the .NET backend.

## Files Changed

| File | Change |
|------|--------|
| maxhanna.Server/Controllers/FlightController.cs | New — Backend proxy for OpenSky states with 15s in-memory cache |
| maxhanna.client/src/services/flight.service.ts | Changed fetchStates() to call /flight/states instead of OpenSky directly |
| maxhanna.client/src/app/globe/globe.component.ts | Auto-load flights on init; clear flightInterval in ngOnDestroy |
| maxhanna.client/src/proxy.conf.js | Added /flight to proxy context |

This PR was written using [Vibe Kanban](https://vibekanban.com)
