### PR TITLE
fix(globe): make globe background transparent for stars and add proper component cleanup (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/globe/globe.component.ts
+++ b/maxhanna.client/src/app/globe/globe.component.ts
@@ -56,7 +56,7 @@ void main() {
   float b    = 2.0 * dot(camPos, rayDir);
   float c    = dot(camPos, camPos) - 1.0;
   float disc = b*b - 4.0*a*c;
-  if (disc < 0.0) { gl_FragColor = vec4(0.0, 0.0, 0.05, 1.0); return; }
+  if (disc < 0.0) { gl_FragColor = vec4(0.0, 0.0, 0.05, 0.0); return; }
 
   float t  = (-b - sqrt(disc)) / (2.0*a);
   vec3 hit = camPos + t * rayDir;
@@ -152,6 +152,9 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   private prog!: WebGLProgram;
   private tex!: WebGLTexture;
   private detailTex!: WebGLTexture;
+  private posBuf!: WebGLBuffer;
+  private vertShader!: WebGLShader;
+  private fragShader!: WebGLShader;
 
   // ---- rotation (row-major 3×3) -------------------------------------------
   private rot = new Float32Array([1, 0, 0, 0, 1, 0, 0, 0, 1]);
@@ -289,7 +292,23 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   ngOnDestroy(): void {
     this.destroyed = true;
     this.stopPingTour();
+    if (this.flightInterval) {
+      clearInterval(this.flightInterval);
+      this.flightInterval = null;
+    }
     cancelAnimationFrame(this.rafId);
+    this.destroyWebGL();
+  }
+
+  private destroyWebGL(): void {
+    const gl = this.gl;
+    if (!gl) return;
+    gl.deleteTexture(this.tex);
+    gl.deleteTexture(this.detailTex);
+    gl.deleteProgram(this.prog);
+    gl.deleteShader(this.vertShader);
+    gl.deleteShader(this.fragShader);
+    gl.deleteBuffer(this.posBuf);
   }
 
   // =========================================================================
@@ -705,22 +724,24 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   // =========================================================================
   private initWebGL(): void {
     const canvas = this.globeCanvasRef.nativeElement;
-    const gl = canvas.getContext('webgl') as WebGLRenderingContext;
+    const gl = canvas.getContext('webgl', { alpha: true, premultipliedAlpha: false }) as WebGLRenderingContext;
     if (!gl) { console.error('WebGL not supported'); return; }
     this.gl = gl;
+    gl.enable(gl.BLEND);
+    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
 
-    const vert = this.compileShader(gl, gl.VERTEX_SHADER, VERT_SRC);
-    const frag = this.compileShader(gl, gl.FRAGMENT_SHADER, FRAG_SRC);
+    this.vertShader = this.compileShader(gl, gl.VERTEX_SHADER, VERT_SRC);
+    this.fragShader = this.compileShader(gl, gl.FRAGMENT_SHADER, FRAG_SRC);
     const prog = gl.createProgram()!;
-    gl.attachShader(prog, vert);
-    gl.attachShader(prog, frag);
+    gl.attachShader(prog, this.vertShader);
+    gl.attachShader(prog, this.fragShader);
     gl.linkProgram(prog);
     if (!gl.getProgramParameter(prog, gl.LINK_STATUS))
       console.error('Shader link error:', gl.getProgramInfoLog(prog));
     this.prog = prog;
 
-    const buf = gl.createBuffer();
-    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    this.posBuf = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, this.posBuf);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
       -1, -1, 1, -1, -1, 1,
       1, -1, 1, 1, -1, 1
@@ -1202,7 +1223,7 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     const h = this.globeCanvasRef.nativeElement.height;
 
     gl.viewport(0, 0, w, h);
-    gl.clearColor(0, 0, 0.05, 1);
+    gl.clearColor(0, 0, 0.05, 0);
     gl.clear(gl.COLOR_BUFFER_BIT);
     gl.useProgram(this.prog);
 

--- a/maxhanna.client/src/app/starry-background/starry-background.component.ts
+++ b/maxhanna.client/src/app/starry-background/starry-background.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 
 @Component({
   selector: 'app-starry-background',
@@ -6,14 +6,17 @@ import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
   styleUrls: ['./starry-background.component.css'],
   standalone: false
 })
-export class StarryBackgroundComponent implements OnInit {
+export class StarryBackgroundComponent implements OnInit, OnDestroy {
   @ViewChild('backgroundCanvas', { static: true }) backgroundCanvas!: ElementRef;
 
   private gl: WebGLRenderingContext | null = null;
   private program: WebGLProgram | null = null;
   private vertexBuffer: WebGLBuffer | null = null;
+  private vertexShader: WebGLShader | null = null;
+  private fragmentShader: WebGLShader | null = null;
   private stars: Float32Array = new Float32Array(0);
   private animationFrameId = 0;
+  private resizeObserver: ResizeObserver | null = null;
 
   constructor() { }
 
@@ -25,6 +28,20 @@ export class StarryBackgroundComponent implements OnInit {
     this.animate();
     // Force render after layout is complete
     setTimeout(() => this.render(), 50);
+  }
+
+  ngOnDestroy(): void {
+    cancelAnimationFrame(this.animationFrameId);
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
+    }
+    if (this.gl) {
+      this.gl.deleteProgram(this.program);
+      if (this.vertexShader) this.gl.deleteShader(this.vertexShader);
+      if (this.fragmentShader) this.gl.deleteShader(this.fragmentShader);
+      this.gl.deleteBuffer(this.vertexBuffer);
+    }
   }
 
   private initWebGL(): void {
@@ -66,13 +83,13 @@ export class StarryBackgroundComponent implements OnInit {
     `;
 
     // Compile shaders
-    const vertexShader = this.compileShader(this.gl.VERTEX_SHADER, vertexShaderSource);
-    const fragmentShader = this.compileShader(this.gl.FRAGMENT_SHADER, fragmentShaderSource);
+    this.vertexShader = this.compileShader(this.gl.VERTEX_SHADER, vertexShaderSource);
+    this.fragmentShader = this.compileShader(this.gl.FRAGMENT_SHADER, fragmentShaderSource);
 
     // Create program
     this.program = this.gl.createProgram()!;
-    this.gl.attachShader(this.program, vertexShader);
-    this.gl.attachShader(this.program, fragmentShader);
+    this.gl.attachShader(this.program, this.vertexShader);
+    this.gl.attachShader(this.program, this.fragmentShader);
     this.gl.linkProgram(this.program);
 
     if (!this.gl.getProgramParameter(this.program, this.gl.LINK_STATUS)) {
@@ -155,13 +172,15 @@ export class StarryBackgroundComponent implements OnInit {
     const canvas = this.backgroundCanvas.nativeElement;
     
     // Handle canvas resize
-    const resizeObserver = new ResizeObserver(() => {
+    this.resizeObserver = new ResizeObserver(() => {
       canvas.width = canvas.clientWidth;
       canvas.height = canvas.clientHeight;
-      this.gl!.viewport(0, 0, canvas.width, canvas.height);
+      if (this.gl) {
+        this.gl.viewport(0, 0, canvas.width, canvas.height);
+      }
     });
     
-    resizeObserver.observe(canvas);
+    this.resizeObserver.observe(canvas);
   }
 
   private animate(): void {


### PR DESCRIPTION
﻿## Summary

Two related fixes for the Globe component on the SigInt page:

- **Stars now visible behind the globe**: The globe's WebGL canvas was fully opaque (including the "space" area around the earth), blocking the starry background behind it. The miss-pixel and clear color alpha are now set to 0.0 with premultipliedAlpha: false so the starry sky shows through.
- **Proper component cleanup on destroy**: When closing the SigInt component, the Globe and StarryBackground components now properly clean up all resources - flight tracking intervals, WebGL textures/programs/shaders/buffers, animation frames, and ResizeObservers - preventing memory leaks.

## Changes

### globe.component.ts
- Fragment shader: changed miss-pixel alpha from 1.0 to 0.0 so space around the globe is transparent
- WebGL context: added { alpha: true, premultipliedAlpha: false } for correct compositing with the starry background behind it
- Enabled WebGL blending (SRC_ALPHA / ONE_MINUS_SRC_ALPHA)
- renderGlobe(): changed gl.clearColor alpha from 1 to 0
- ngOnDestroy(): now clears the flight tracking interval and calls destroyWebGL() to delete all WebGL resources
- Stored shader and buffer references (vertShader, fragShader, posBuf) so they can be explicitly deleted on destroy

### starry-background.component.ts
- Implements OnDestroy lifecycle hook (was missing entirely)
- ngOnDestroy(): cancels the animation frame, disconnects the ResizeObserver, and deletes the WebGL program, shaders, and buffer
- Stored shader and ResizeObserver references (were local variables before)

## Destruction Order

Angular's component destruction is child-first, so GlobeComponent.ngOnDestroy() and StarryBackgroundComponent.ngOnDestroy() run automatically before SigIntComponent's view is fully torn down. The fix ensures both child components clean up everything they own when that happens.

This PR was written using [Vibe Kanban](https://vibekanban.com)
