### PR TITLE
fix(globe): auto-load flight data on add, focus globe on newly added and clicked flights (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/globe/globe.component.css
+++ b/maxhanna.client/src/app/globe/globe.component.css
@@ -375,6 +375,12 @@
   margin-bottom: 6px;
   background: rgba(30, 30, 45, 0.6);
   border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.flight-item:hover {
+  background: rgba(40, 40, 65, 0.8);
 }
 
 .flight-info {

--- a/maxhanna.client/src/app/globe/globe.component.html
+++ b/maxhanna.client/src/app/globe/globe.component.html
@@ -79,7 +79,7 @@
           <button type="button" (click)="toggleFlightTracking()">{{ flightInterval ? 'Stop Tracking' : 'Start Tracking' }}</button>
         </div>
         <div class="flights-list">
-          <div class="flight-item" *ngFor="let flight of trackedFlights">
+          <div class="flight-item" *ngFor="let flight of trackedFlights" (click)="focusTrackedFlight(flight); showDataPanel = false">
             <div class="flight-info">
               <span class="flight-callsign">{{ flight.callsign }}</span>
               <span class="flight-route" *ngIf="flight.origin && flight.destination">{{ flight.origin }} → {{ flight.destination }}</span>

--- a/maxhanna.client/src/app/globe/globe.component.ts
+++ b/maxhanna.client/src/app/globe/globe.component.ts
@@ -282,6 +282,7 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     if (saved.length > 0) {
       this.loadFlights();
     }
+    this.loadAllFlights();
   }
 
   ngAfterViewInit(): void {
@@ -362,7 +363,7 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
-  addFlight(): void {
+  async addFlight(): Promise<void> {
     const cs = this.newCallsign.trim().toUpperCase();
     if (!cs) return;
 
@@ -401,7 +402,41 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     this.newCallsign = '';
 
     if (!this.flightInterval) {
-      this.loadFlights();
+      await this.loadFlights();
+    } else {
+      await this.loadAllFlights();
+    }
+
+    if (lat === undefined || lon === undefined) {
+      for (const state of this.allFlightStates) {
+        const scs = state[1]?.trim().toUpperCase();
+        if (scs === cs) {
+          lat = state[6];
+          lon = state[5];
+          altitude = state[7];
+          heading = state[10];
+          velocity = state[9];
+          break;
+        }
+      }
+      if (lat !== undefined && lon !== undefined) {
+        this.trackedFlights = this.trackedFlights.map(f =>
+          f.id === flight.id ? { ...f, lat, lon, altitude, heading, velocity } : f
+        );
+        this.flightService.saveTrackedFlights(this.trackedFlights);
+      }
+    }
+
+    if (lat !== undefined && lon !== undefined) {
+      this.focusPing({
+        id: `flight:${cs}`,
+        lat,
+        lon,
+        label: cs,
+        zoom: 0,
+        source: 'custom',
+        data: { type: 'flight', callsign: cs },
+      });
     }
   }
 
@@ -448,6 +483,22 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     this.showFlightDetail = true;
     this.showDataPanel = false;
     this.focusPing(ping);
+  }
+
+  focusTrackedFlight(flight: TrackedFlight): void {
+    const lat = flight.lat;
+    const lon = flight.lon;
+    if (lat != null && lon != null) {
+      this.focusPing({
+        id: `flight:${flight.callsign}`,
+        lat,
+        lon,
+        label: flight.callsign,
+        zoom: 0,
+        source: 'custom',
+        data: { type: 'flight', callsign: flight.callsign },
+      });
+    }
   }
 
   closeFlightDetail(): void {


### PR DESCRIPTION
## Summary

Fixes three issues with the flight tracker: newly added flights not appearing on the globe, no data showing in the flight list after adding, and missing click-to-focus interaction on flight list items.

## Changes

### 1. Auto-load flight states on init (`globe.component.ts`)
- `allFlightStates` is now always fetched on component init, even when there are no saved flights. Previously, the API was only called if saved flights existed, so adding a first flight would have no state data to look up.

### 2. Fetch and apply live position data after adding a flight (`globe.component.ts`)
- `addFlight()` is now `async` and **awaits** the API response from `loadFlights()` / `loadAllFlights()` before returning.
- If the flight's position wasn't found in `allFlightStates` initially (because data wasn't loaded yet), it re-scans the freshly loaded states for the callsign match.
- When a position is found, the `TrackedFlight` entry is updated in memory and saved to localStorage, so the flight list immediately shows altitude, heading, and speed instead of "N/A".

### 3. Auto-focus globe on newly added flight (`globe.component.ts`)
- After successfully looking up a position, the globe rotates and zooms to focus on the new flight's location.

### 4. Click flight list item to focus globe (`globe.component.html`, `globe.component.ts`, `globe.component.css`)
- Added `(click)="focusTrackedFlight(flight); showDataPanel = false"` on each flight list item.
- Added `focusTrackedFlight()` method that finds the flight's lat/lon and calls `focusPing()`.
- Added `cursor: pointer` and hover styling to `.flight-item` for visual affordance.

## Why

When a user adds a flight like "AFR29" to the tracker, they expect to see the plane appear on the globe and data populate in the list immediately. The original code had a timing issue where `allFlightStates` was empty on first use, and `loadFlights()` wasn't awaited, so the tracked flight's position was never populated from the API response.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)
