### PR TITLE
feat(globe): show news article popup on pin click instead of opening tab directly (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/globe/globe.component.css
+++ b/maxhanna.client/src/app/globe/globe.component.css
@@ -507,3 +507,62 @@
   color: #fff;
   text-align: right;
 }
+
+/* ---- News Article Popup ---- */
+.news-popup-backdrop {
+  position: fixed;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  background: rgba(0,0,0,0.5);
+  z-index: 999;
+}
+
+.news-popup-panel.popupPanel {
+  max-width: 500px;
+  width: 90vw;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.news-popup-image {
+  max-width: 100%;
+  max-height: 250px;
+  object-fit: cover;
+  border-radius: 6px;
+}
+
+.news-popup-description {
+  color: #ccc;
+  font-size: 14px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.news-popup-meta,
+.news-popup-date {
+  color: #888;
+  font-size: 12px;
+  margin: 0;
+}
+
+.news-popup-open-btn {
+  align-self: center;
+  padding: 10px 24px;
+  background: #2a6ef0;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.news-popup-open-btn:hover {
+  background: #1a5ed8;
+}
+
+@media (max-width: 667px) {
+  .news-popup-panel.popupPanel {
+    width: calc(100vw - 50px);
+  }
+}

--- a/maxhanna.client/src/app/globe/globe.component.html
+++ b/maxhanna.client/src/app/globe/globe.component.html
@@ -120,4 +120,16 @@
       <div class="detail-row" *ngIf="selectedFlight.lastUpdated"><span class="detail-label">Updated:</span><span>{{ selectedFlight.lastUpdated | date:'medium' }}</span></div>
     </div>
   </div>
+
+  <!-- News Article Popup -->
+  <div class="news-popup-backdrop" *ngIf="showNewsPopup" (click)="closeNewsPopup()"></div>
+  <div class="popupPanel news-popup-panel" *ngIf="showNewsPopup && selectedNewsPin">
+    <div class="popupPanelTitle">{{ selectedNewsPin.articleTitle }}</div>
+    <button class="close-btn" (click)="closeNewsPopup()">×</button>
+    <img *ngIf="selectedNewsPin.urlToImage" [src]="selectedNewsPin.urlToImage" alt="Article image" class="news-popup-image">
+    <p class="news-popup-description">{{ selectedNewsPin.description || 'No description available.' }}</p>
+    <p class="news-popup-meta">Location: {{ selectedNewsPin.label }} ({{ selectedNewsPin.locationType }})</p>
+    <p class="news-popup-date" *ngIf="selectedNewsPin.createdAt">Published: {{ selectedNewsPin.createdAt | date:'mediumDate' }}</p>
+    <button type="button" class="news-popup-open-btn" (click)="openNewsArticleInNewTab()">Open Article in New Tab</button>
+  </div>
 </div>

--- a/maxhanna.client/src/app/globe/globe.component.ts
+++ b/maxhanna.client/src/app/globe/globe.component.ts
@@ -193,6 +193,8 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   newCallsign = '';
   selectedFlight: any = null;
   showFlightDetail = false;
+  selectedNewsPin: NewsPin | null = null;
+  showNewsPopup = false;
   flightArcs: Arc[] = [];
 
   // ---- coordinates display -------------------------------------------------
@@ -507,6 +509,17 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     this.flightArcs = [];
   }
 
+  closeNewsPopup(): void {
+    this.showNewsPopup = false;
+    this.selectedNewsPin = null;
+  }
+
+  openNewsArticleInNewTab(): void {
+    if (this.selectedNewsPin?.articleUrl) {
+      window.open(this.selectedNewsPin.articleUrl, '_blank');
+    }
+  }
+
   // =========================================================================
   // Stories
   // =========================================================================
@@ -576,6 +589,8 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onNewsPinClick(pin: NewsPin): void {
+    this.selectedNewsPin = pin;
+    this.showNewsPopup = true;
     const ping = this.newsPinToPing(pin);
     if (ping) this.focusPing(ping);
   }
@@ -1663,8 +1678,9 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.dragMoved) return;
     const ping = this.findPingAtEvent(e);
     if (!ping) return;
-    if (ping.source === 'news' && ping.newsPin?.articleUrl) {
-      window.open(ping.newsPin.articleUrl, '_blank');
+    if (ping.source === 'news' && ping.newsPin) {
+      this.selectedNewsPin = ping.newsPin;
+      this.showNewsPopup = true;
       return;
     }
     const pingData = ping.data as any;


### PR DESCRIPTION
## Summary

Clicking a news article pin on the globe now opens a popup panel showing the article's details (title, image, description, location, date), instead of immediately opening the article URL in a new tab. The user can then click an "Open Article in New Tab" button within the popup to navigate to the article.

## Changes

**globe.component.ts:**
- Added `selectedNewsPin` and `showNewsPopup` state properties
- Changed the `onClick` handler for news pins to set the popup state instead of calling `window.open()` directly
- Updated `onNewsPinClick` (used from the data panel news list) to also show the popup
- Added `closeNewsPopup()` and `openNewsArticleInNewTab()` methods

**globe.component.html:**
- Added a new popup panel with backdrop, reusing the existing `.popupPanel` CSS class
- Displays article title, image (if available), description, location, and publish date
- Includes an "Open Article in New Tab" button that opens `articleUrl` via `window.open()`

**globe.component.css:**
- Added styles for the news popup backdrop, image, description text, meta fields, and action button

## Implementation Details

The popup follows the same pattern as the existing flight detail popup in the globe component — a backdrop overlay with a centered panel, toggled by boolean flags. The `.popupPanel` global CSS class is reused for consistent styling across the app.

This PR was written using [Vibe Kanban](https://vibekanban.com)
