### PR TITLE
feat(globe): add Users tab with location pins from weather_location (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Controllers/UserController.cs
+++ b/maxhanna.Server/Controllers/UserController.cs
@@ -1422,6 +1422,51 @@ namespace maxhanna.Server.Controllers
       }
     }
 
+    [HttpGet("/User/GetUsersWithLocations", Name = "GetUsersWithLocations")]
+    public async Task<IActionResult> GetUsersWithLocations()
+    {
+      MySqlConnection conn = new MySqlConnection(_config.GetValue<string>("ConnectionStrings:maxhanna"));
+      try
+      {
+        conn.Open();
+        string sql = @"
+          SELECT u.id, u.username, wl.location, wl.city, wl.country 
+          FROM maxhanna.users u 
+          LEFT JOIN maxhanna.weather_location wl ON wl.ownership = u.id 
+          LEFT JOIN maxhanna.user_settings us ON us.user_id = u.id 
+          WHERE (us.display_profile_location IS NULL OR us.display_profile_location = 1)
+            AND (wl.city IS NOT NULL OR wl.country IS NOT NULL)";
+
+        MySqlCommand cmd = new MySqlCommand(sql, conn);
+        var users = new List<object>();
+
+        using (var reader = await cmd.ExecuteReaderAsync())
+        {
+          while (await reader.ReadAsync())
+          {
+            users.Add(new {
+              Id = Convert.ToInt32(reader["id"]),
+              Username = reader["username"].ToString(),
+              Location = reader.IsDBNull(reader.GetOrdinal("location")) ? null : reader.GetString("location"),
+              City = reader.IsDBNull(reader.GetOrdinal("city")) ? null : reader.GetString("city"),
+              Country = reader.IsDBNull(reader.GetOrdinal("country")) ? null : reader.GetString("country")
+            });
+          }
+        }
+
+        return users.Count > 0 ? Ok(users) : NotFound();
+      }
+      catch (Exception ex)
+      {
+        _ = _log.Db("Error in GetUsersWithLocations: " + ex.Message, null, "USER", true);
+        return StatusCode(500, "An error occurred.");
+      }
+      finally
+      {
+        conn.Close();
+      }
+    }
+
     [HttpPost(Name = "LogIn")]
     public async Task<IActionResult> LogIn([FromBody] Dictionary<string, string> body)
     {

--- a/maxhanna.client/src/app/globe/globe.component.css
+++ b/maxhanna.client/src/app/globe/globe.component.css
@@ -442,6 +442,42 @@
   font-size: 13px;
 }
 
+/* Users List */
+.users-list {
+  overflow-y: auto;
+}
+
+.user-item {
+  padding: 12px;
+  margin-bottom: 8px;
+  background: rgba(30, 30, 45, 0.6);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.user-item:hover {
+  background: rgba(40, 40, 60, 0.8);
+}
+
+.user-name {
+  font-weight: 600;
+  color: #44ff88;
+  margin-bottom: 4px;
+}
+
+.user-location {
+  color: #777;
+  font-size: 11px;
+}
+
+.no-users {
+  text-align: center;
+  color: #666;
+  padding: 20px;
+  font-size: 13px;
+}
+
 /* Flight Detail Popup */
 .flight-detail-backdrop {
   position: fixed;

--- a/maxhanna.client/src/app/globe/globe.component.html
+++ b/maxhanna.client/src/app/globe/globe.component.html
@@ -28,6 +28,8 @@
               (click)="activeDataTab = 'news'">News</button>
       <button type="button" class="tab-btn" [class.active]="activeDataTab === 'flights'"
               (click)="activeDataTab = 'flights'">Flights</button>
+      <button type="button" class="tab-btn" [class.active]="activeDataTab === 'users'"
+              (click)="activeDataTab = 'users'">Users</button>
     </div>
 
     <div class="data-content" *ngIf="activeDataTab === 'stories'">
@@ -96,6 +98,18 @@
           <div class="no-flights" *ngIf="trackedFlights.length === 0">
             No flights tracked yet. Add a flight above.
           </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="data-content" *ngIf="activeDataTab === 'users'">
+      <div class="users-list">
+        <div class="user-item" *ngFor="let user of usersWithLocations" (click)="onUserClick(user)">
+          <div class="user-name">{{ user.username }}</div>
+          <div class="user-location">{{ formatLocationLabel(user.city, user.country) }}</div>
+        </div>
+        <div class="no-users" *ngIf="usersWithLocations.length === 0">
+          No users with locations found.
         </div>
       </div>
     </div>

--- a/maxhanna.client/src/app/globe/globe.component.ts
+++ b/maxhanna.client/src/app/globe/globe.component.ts
@@ -11,6 +11,7 @@ import { Story } from '../../services/datacontracts/social/story';
 import { TileCacheService } from '../services/tile-cache.service';
 import { FlightService } from '../../services/flight.service';
 import { TrackedFlight } from '../../services/datacontracts/flight';
+import { UserService, UserWithLocation } from '../../services/user.service';
 
 // ---------------------------------------------------------------------------
 // Vertex shader
@@ -115,9 +116,10 @@ export interface ResolvedGlobePing {
   lon: number;
   label: string;
   zoom: number;
-  source: 'story' | 'custom' | 'news';
+  source: 'story' | 'custom' | 'news' | 'user';
   story?: Story;
   newsPin?: NewsPin;
+  user?: UserWithLocation;
   data?: unknown;
 }
 
@@ -185,7 +187,8 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   // ---- flight pins ---------------------------------------------------------
   trackedFlights: TrackedFlight[] = [];
   allFlightStates: any[] = [];
-  activeDataTab: 'stories' | 'news' | 'flights' = 'stories';
+  activeDataTab: 'stories' | 'news' | 'flights' | 'users' = 'stories';
+  usersWithLocations: UserWithLocation[] = [];
   private flightsLoaded = false;
   private allFlightsLoaded = false;
   flightInterval: ReturnType<typeof setInterval> | null = null;
@@ -271,7 +274,8 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     private ngZone: NgZone,
     private encryptionService: EncryptionService,
     private tileCacheService: TileCacheService,
-    private flightService: FlightService
+    private flightService: FlightService,
+    private userService: UserService
   ) { }
 
   // =========================================================================
@@ -280,6 +284,7 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   ngOnInit(): void {
     this.loadStories();
     this.loadNewsPins();
+    this.loadUsersWithLocations();
     const saved = this.flightService.getTrackedFlights();
     if (saved.length > 0) {
       this.loadFlights();
@@ -560,6 +565,12 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     } catch { /* non-fatal */ }
   }
 
+  private async loadUsersWithLocations(): Promise<void> {
+    try {
+      this.usersWithLocations = await this.userService.getUsersWithLocations();
+    } catch { /* non-fatal */ }
+  }
+
   get dateFilterLabel(): string {
     if (!this.minDate || !this.maxDate) return 'All time';
     const totalMs = this.maxDate.getTime() - this.minDate.getTime();
@@ -593,6 +604,14 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     this.showNewsPopup = true;
     const ping = this.newsPinToPing(pin);
     if (ping) this.focusPing(ping);
+  }
+
+  onUserClick(user: UserWithLocation): void {
+    const ping = this.userToPing(user);
+    if (ping) {
+      this.focusPing(ping);
+      this.showDataPanel = false;
+    }
   }
 
   focusPing(ping: ResolvedGlobePing | GlobePing): void {
@@ -652,9 +671,12 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     const customPings = this.customPings
       .map((ping, index) => this.resolveCustomPing(ping, index))
       .filter((ping): ping is ResolvedGlobePing => !!ping);
+    const userPings = this.usersWithLocations
+      .map(user => this.userToPing(user))
+      .filter((ping): ping is ResolvedGlobePing => !!ping);
 
     const flightPings = this.getFlightPings();
-    return [...storyPings, ...newsPings, ...customPings, ...flightPings];
+    return [...storyPings, ...newsPings, ...customPings, ...userPings, ...flightPings];
   }
 
   private getFlightPings(): ResolvedGlobePing[] {
@@ -732,6 +754,22 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
       zoom: pin.locationType === 'city' ? 82 : 58,
       source: 'news',
       newsPin: pin,
+    };
+  }
+
+  private userToPing(user: UserWithLocation): ResolvedGlobePing | null {
+    const coords = user.city
+      ? this.lookupCityCoords(user.city, user.country)
+      : this.lookupCoords(this.COUNTRY_COORDS, user.country);
+    if (!coords) return null;
+    return {
+      id: `user:${user.id}`,
+      lat: coords[0],
+      lon: coords[1],
+      label: user.username,
+      zoom: user.city ? 82 : 58,
+      source: 'user',
+      user: user,
     };
   }
 
@@ -1339,6 +1377,7 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   
       const color = ping.source === 'story' ? '255, 80, 80'
         : ping.source === 'news' ? '255, 180, 50'
+        : ping.source === 'user' ? '74, 255, 100'
         : '74, 170, 255';
       const flightData = ping.data as any;
       const isFlight = flightData?.type === 'flight';
@@ -1358,7 +1397,7 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
  
       ctx.beginPath();
       ctx.arc(x, y, isActive ? 5 : 4, 0, Math.PI * 2);
-      ctx.fillStyle = ping.source === 'story' ? '#ff4444' : ping.source === 'news' ? '#44ff44' : '#4aaaff';
+      ctx.fillStyle = ping.source === 'story' ? '#ff4444' : ping.source === 'news' ? '#44ff44' : ping.source === 'user' ? '#44ff88' : '#4aaaff';
   
       ctx.strokeStyle = '#ffffff';
       ctx.lineWidth = 1.5;
@@ -1370,6 +1409,9 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
           break;
         case 'news':
           this.drawNewsIcon(ctx, x, y, s);
+          break;
+        case 'user':
+          this.drawUserIcon(ctx, x, y, s);
           break;
         default:
           this.drawCustomIcon(ctx, x, y, s);
@@ -1575,6 +1617,18 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     ctx.closePath();
     ctx.fill();
     ctx.stroke();
+  }
+
+  private drawUserIcon(ctx: CanvasRenderingContext2D, x: number, y: number, s: number): void {
+    ctx.beginPath();
+    ctx.arc(x, y - s * 0.15, s * 0.7, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.arc(x, y - s * 0.4, s * 0.35, 0, Math.PI * 2);
+    ctx.fillStyle = '#fff';
+    ctx.fill();
   }
 
   private projectPin(latDeg: number, lngDeg: number, w: number, h: number)
@@ -1817,7 +1871,7 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
       .replace(/\s+/g, ' ').trim().toLowerCase();
   }
 
-  private formatLocationLabel(city?: string, country?: string): string {
+  formatLocationLabel(city?: string, country?: string): string {
     const c = city?.trim(), co = country?.trim();
     return (c && co) ? `${c}, ${co}` : c || co || 'Unknown location';
   }

--- a/maxhanna.client/src/services/user.service.ts
+++ b/maxhanna.client/src/services/user.service.ts
@@ -20,6 +20,14 @@ export interface ActiveGamer {
   user?: User;
 }
 
+export interface UserWithLocation {
+  id: number;
+  username: string;
+  location?: string;
+  city?: string;
+  country?: string;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -871,6 +879,21 @@ export class UserService {
       return await response.json();
     } catch {
       return null;
+    }
+  }
+
+  async getUsersWithLocations(): Promise<UserWithLocation[]> {
+    try {
+      const response = await fetch('/user/getuserswithlocations', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.status === 404) return [];
+      if (!response.ok) return [];
+      return await response.json() as UserWithLocation[];
+    } catch (error) {
+      console.error('Error fetching users with locations:', error);
+      return [];
     }
   }
 


### PR DESCRIPTION
## Summary

Adds a new **Users** tab to the globe's data panel that displays site users who have set their weather location, allowing the user to click on any listed user and zoom the globe to their pinned location.

## Changes

### Server-side
- **`UserController.cs`**: New `GET /User/GetUsersWithLocations` endpoint that LEFT JOINs `users` -> `weather_location` -> `user_settings`, returning user id, username, city, and country. Users with `display_profile_location = 0` in their settings are excluded.

### Client-side
- **`user.service.ts`**: Added `UserWithLocation` interface and `getUsersWithLocations()` method.
- **`globe.component.ts`**:
  - Added `'user'` to `ResolvedGlobePing.source` union type and `user?` field
  - Added `loadUsersWithLocations()` to fetch users on init
  - Added `userToPing()` -- resolves user city/country to lat/lon using existing coordinate lookup tables
  - Added `onUserClick()` -- zooms the globe to the user's location and closes the data panel
  - Updated `getAllPings()` to include user pings in the pin renderer
  - Users render as green pins (`#44ff88`) with a person-shaped icon
- **`globe.component.html`**: Added Users tab button and users list section
- **`globe.component.css`**: Styled user list items matching the existing data panel design language

## Implementation Details

- Coordinate resolution for user locations reuses the existing `lookupCityCoords`/`lookupCoords` methods and the pre-defined `CITY_COORDS`/`COUNTRY_COORDS` lookup tables already in the globe component.
- Users without a city/country in `weather_location` are excluded from the query.
- The `display_profile_location` user setting controls visibility -- if set to `0`, the user won't appear on the globe.

This PR was written using [Vibe Kanban](https://vibekanban.com)
