### PR TITLE
fix(crawler): persist scraped search results so they can be rated (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Controllers/CrawlerController.cs
+++ b/maxhanna.Server/Controllers/CrawlerController.cs
@@ -142,6 +142,12 @@ namespace maxhanna.Server.Controllers
           }, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.RunContinuationsAsynchronously);
         }
 
+        // Persist any scraped results that don't have database IDs so they can be rated
+        if (results.Any(r => !r.Id.HasValue))
+        {
+            await PersistScrapedResults(results, connectionString!);
+        }
+
         // Post-process
         var allResults = GetOrderedResultsForWeb(request, results);
         allResults = await AddFavouriteCountsAsync(allResults, request.UserId);
@@ -165,6 +171,18 @@ namespace maxhanna.Server.Controllers
               if (wiki.Url != null)
               {
                 await _webCrawler.SaveSearchResult(wiki.Url, wiki);
+                // Retrieve the database-assigned ID so the result can be rated
+                using (var idConn = new MySqlConnection(connectionString))
+                {
+                  await idConn.OpenAsync();
+                  using (var idCmd = new MySqlCommand("SELECT id FROM search_results WHERE url = @url LIMIT 1", idConn))
+                  {
+                    idCmd.Parameters.AddWithValue("@url", wiki.Url);
+                    var idResult = await idCmd.ExecuteScalarAsync();
+                    if (idResult != null)
+                      wiki.Id = Convert.ToInt32(idResult);
+                  }
+                }
               }
               // Keep your normalization pipeline consistent
               wikiOnly = GetOrderedResultsForWeb(request, wikiOnly);
@@ -880,6 +898,32 @@ namespace maxhanna.Server.Controllers
       }
 
       return searchResults;
+    }
+
+    private async Task PersistScrapedResults(List<Metadata> results, string connectionString)
+    {
+      foreach (var r in results.Where(x => !x.Id.HasValue && !string.IsNullOrWhiteSpace(x.Url)))
+      {
+        try
+        {
+          await _webCrawler.SaveSearchResult(r.Url, r);
+          using (var idConn = new MySqlConnection(connectionString))
+          {
+            await idConn.OpenAsync();
+            using (var idCmd = new MySqlCommand("SELECT id FROM search_results WHERE url = @url LIMIT 1", idConn))
+            {
+              idCmd.Parameters.AddWithValue("@url", r.Url);
+              var idResult = await idCmd.ExecuteScalarAsync();
+              if (idResult != null)
+                r.Id = Convert.ToInt32(idResult);
+            }
+          }
+        }
+        catch (Exception ex)
+        {
+          _ = _log.Db($"Could not persist scraped result for {r.Url}: {ex.Message}", null, "CRAWLERCTRL", true);
+        }
+      }
     }
 
     private async Task<List<Metadata>> ExecuteResultsAsync(


### PR DESCRIPTION
﻿## Summary

When the crawler component is used inside the favourites component (onlySearch mode), search results from quick scraping lack a database search_results.id. The RatingStarsComponent requires a valid id to submit ratings, causing the "No rating file available to rate" error.

## Changes

**File modified:** CrawlerController.cs

1. **New helper method PersistScrapedResults()** — Iterates over search results without a database Id, persists each one to the search_results table via SaveSearchResult(), then retrieves the auto-generated ID and assigns it back to the metadata object.

2. **Called after merging quick-scraped results** — Before post-processing (favourite counts, rating data aggregation), any scraped result without an ID is persisted so downstream steps like AddRatingDataAsync() can associate ratings.

3. **Wikipedia fallback fix** — After saving the Wikipedia result to the database, the assigned ID is now retrieved so it can also be rated.

## Why

When users search in the crawler from the favourites component, the backend may return freshly scraped results that haven't been persisted to the search_results table. Without a database ID, the frontend rating stars component cannot submit ratings, and the backend rating aggregation (AddRatingDataAsync) skips those results entirely. Persisting them before the response ensures every result has a valid ID.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)
