### PR TITLE
fix(comments): respect display_profile_location setting when showing comment location (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Controllers/FileController.cs
+++ b/maxhanna.Server/Controllers/FileController.cs
@@ -1,4 +1,4 @@
-﻿using FirebaseAdmin.Messaging;
+using FirebaseAdmin.Messaging;
 using maxhanna.Server.Controllers.DataContracts;
 using maxhanna.Server.Controllers.DataContracts.Files;
 using maxhanna.Server.Controllers.DataContracts.Topics;
@@ -816,7 +816,8 @@ namespace maxhanna.Server.Controllers
 
             -- favourites: count is real; is_favourited is 0 here (no @userId in this method)
             (SELECT COUNT(*) FROM file_favourites ff WHERE ff.file_id = cf2.id) AS commentFileEntryFavouriteCount,
-            CAST(0 AS SIGNED) AS commentFileEntryIsFavourited
+            CAST(0 AS SIGNED) AS commentFileEntryIsFavourited,
+            COALESCE(us.display_profile_location, 1) AS commentDisplayProfileLocation
 
         FROM maxhanna.comments fc
         LEFT JOIN maxhanna.users uc ON fc.user_id = uc.id
@@ -827,6 +828,7 @@ namespace maxhanna.Server.Controllers
         LEFT JOIN maxhanna.comment_files cf ON fc.id = cf.comment_id
         LEFT JOIN maxhanna.file_uploads cf2 ON cf.file_id = cf2.id
         LEFT JOIN maxhanna.users cfu2 ON cfu2.id = cf2.user_id
+        LEFT JOIN maxhanna.user_settings us ON us.user_id = fc.user_id
 
         WHERE fc.id IN (SELECT id FROM comment_tree);", connection);
 
@@ -844,8 +846,9 @@ namespace maxhanna.Server.Controllers
       {
         var commentId = reader.IsDBNull(reader.GetOrdinal("commentId")) ? 0 : reader.GetInt32("commentId");
         var fileIdValue = reader.IsDBNull(reader.GetOrdinal("commentFileId")) ? 0 : reader.GetInt32("commentFileId");
-        var commentCity = reader.IsDBNull(reader.GetOrdinal("commentCity")) ? null : reader.GetString("commentCity");
-        var commentCountry = reader.IsDBNull(reader.GetOrdinal("commentCountry")) ? null : reader.GetString("commentCountry");
+        var commentDisplayProfileLocation = reader.GetBoolean("commentDisplayProfileLocation");
+        var commentCity = (!commentDisplayProfileLocation || reader.IsDBNull(reader.GetOrdinal("commentCity"))) ? null : reader.GetString("commentCity");
+        var commentCountry = (!commentDisplayProfileLocation || reader.IsDBNull(reader.GetOrdinal("commentCountry"))) ? null : reader.GetString("commentCountry");
         var commentIp = reader.IsDBNull(reader.GetOrdinal("commentIp")) ? null : reader.GetString("commentIp");
         int? commentParentId = reader.IsDBNull(reader.GetOrdinal("comment_parent_id")) ? null : reader.GetInt32("comment_parent_id");
 

--- a/maxhanna.Server/Controllers/SocialController.cs
+++ b/maxhanna.Server/Controllers/SocialController.cs
@@ -1232,7 +1232,8 @@ namespace maxhanna.Server.Controllers
 					ru.username AS reaction_username,
 					rudp.file_id AS reaction_display_picture_file_id,
 					r.timestamp AS reaction_time,
-					c.comment_id AS parent_comment_id
+					c.comment_id AS parent_comment_id,
+					COALESCE(us.display_profile_location, 1) AS comment_display_profile_location
 				FROM 
 					comments AS c
 				LEFT JOIN 
@@ -1255,6 +1256,8 @@ namespace maxhanna.Server.Controllers
 					users AS ru ON r.user_id = ru.id   
 				LEFT JOIN 
 					user_display_pictures AS rudp ON rudp.user_id = ru.id   
+				LEFT JOIN 
+					user_settings AS us ON us.user_id = c.user_id
 				WHERE c.id IN (SELECT id FROM comment_tree)
 				{whereC} 
 				GROUP BY c.id, r.id, r.type, ru.id, ru.username, r.timestamp, 
@@ -1290,8 +1293,9 @@ namespace maxhanna.Server.Controllers
               var cuserId = rdr.GetInt32("comment_user_id");
               var userName = rdr.GetString("comment_username");
               var commentText = rdr.GetString("comment");
-              var commentCity = rdr.IsDBNull(rdr.GetOrdinal("comment_city")) ? null : rdr.GetString("comment_city");
-              var commentCountry = rdr.IsDBNull(rdr.GetOrdinal("comment_country")) ? null : rdr.GetString("comment_country");
+              var displayProfileLocation = rdr.GetBoolean("comment_display_profile_location");
+              var commentCity = (!displayProfileLocation || rdr.IsDBNull(rdr.GetOrdinal("comment_city"))) ? null : rdr.GetString("comment_city");
+              var commentCountry = (!displayProfileLocation || rdr.IsDBNull(rdr.GetOrdinal("comment_country"))) ? null : rdr.GetString("comment_country");
               var commentIp = rdr.IsDBNull(rdr.GetOrdinal("comment_ip")) ? null : rdr.GetString("comment_ip");
               var date = rdr.GetDateTime("date");
 


### PR DESCRIPTION
When a user sets `display_profile_location` to `0` in their `user_settings`, their location was still visible in the comment options panel on both stories and file comments. This change ensures the comment author's `display_profile_location` preference is respected everywhere location data appears.

**Changes:**

- **SocialController.cs**: Added `LEFT JOIN user_settings` to the comment-fetching SQL query and reads `display_profile_location` per comment author. When the flag is `0`, `city` and `country` are returned as `null` instead of their stored values.
- **FileController.cs**: Same pattern applied to the `GetFileComments` query for file-level comments.

**Implementation details:**

- Uses `COALESCE(us.display_profile_location, 1)` so comments from users without a `user_settings` row default to showing location (backward-compatible).
- Follows the existing pattern already used for story-level location hiding at `SocialController.cs:351-352`.
- The frontend `formatCommentMetadata()` already handles null `city`/`country` gracefully — no frontend changes were needed.

This PR was written using [Vibe Kanban](https://vibekanban.com)