### PR TITLE
Add user_events tracking system with site-wide activity feed component (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Controllers/BonesController.cs
+++ b/maxhanna.Server/Controllers/BonesController.cs
@@ -1,7 +1,7 @@
 using maxhanna.Server.Controllers.DataContracts.Bones;
+using maxhanna.Server.Controllers.DataContracts.Meta;
+using maxhanna.Server.Controllers.DataContracts.UserEvents;
 using maxhanna.Server.Controllers.DataContracts.Users;
-using maxhanna.Server.Controllers.DataContracts.Files;
-using maxhanna.Server.Controllers.DataContracts; // PartyMemberDto
 using Microsoft.AspNetCore.Mvc;
 using MySqlConnector;
 using System.Text;
@@ -124,6 +124,33 @@ namespace maxhanna.Server.Controllers
           killerNotifCmd.Parameters.AddWithValue("@KillerHeroId", killerId.Value);
           await killerNotifCmd.ExecuteNonQueryAsync();
         }
+        try
+        {
+            using (var nameCmd = new MySqlCommand("SELECT u.id, u.username FROM maxhanna.bones_hero v LEFT JOIN maxhanna.bones_hero kh ON kh.id = @KillerHeroId2 LEFT JOIN maxhanna.users u ON u.id = kh.user_id WHERE v.id = @VictimHeroId2 LIMIT 1", connection, transaction))
+            {
+                nameCmd.Parameters.AddWithValue("@VictimHeroId2", victimId);
+                nameCmd.Parameters.AddWithValue("@KillerHeroId2", killerId);
+                using (var rdr = await nameCmd.ExecuteReaderAsync())
+                {
+                    if (await rdr.ReadAsync())
+                    {
+                        int userId = rdr.IsDBNull(0) ? 0 : rdr.GetInt32(0);
+                        string? username = rdr.IsDBNull(1) ? null : rdr.GetString(1);
+                        if (userId > 0 && killerId.HasValue && killerId.Value != victimId)
+                        {
+                            string eventText = $"{username ?? "Someone"} killed someone in Bones!";
+                            await UserEventController.InsertUserEventWithConnection(userId, username, "bones_kill", eventText, victimId, "bones_hero", connection, transaction);
+                        }
+                        else if (userId > 0)
+                        {
+                            string eventText = $"{username ?? "Someone"} died in Bones.";
+                            await UserEventController.InsertUserEventWithConnection(userId, username, "bones_death", eventText, victimId, "bones_hero", connection, transaction);
+                        }
+                    }
+                }
+            }
+        }
+        catch { }
       }
       catch (Exception ex)
       {

--- a/maxhanna.Server/Controllers/CommentController.cs
+++ b/maxhanna.Server/Controllers/CommentController.cs
@@ -1,6 +1,7 @@
 using maxhanna.Server.Controllers.DataContracts;
 using maxhanna.Server.Controllers.DataContracts.Comments;
 using maxhanna.Server.Controllers.DataContracts.Files;
+using maxhanna.Server.Controllers.DataContracts.UserEvents;
 using maxhanna.Server.Controllers.DataContracts.Users;
 using Microsoft.AspNetCore.Mvc;
 using MySqlConnector;
@@ -122,7 +123,24 @@ namespace maxhanna.Server.Controllers
 						}
 					}
 
-					return Ok($"{insertedId} Comment Successfully Added");
+          if (insertedId != 0 && request.UserId > 0)
+          {
+              string? username = null;
+              using (var nameConn = new MySqlConnection(connectionString))
+              {
+                  await nameConn.OpenAsync();
+                  using (var nameCmd = new MySqlCommand("SELECT username FROM maxhanna.users WHERE id = @id LIMIT 1", nameConn))
+                  {
+                      nameCmd.Parameters.AddWithValue("@id", request.UserId);
+                      var nameResult = await nameCmd.ExecuteScalarAsync();
+                      username = nameResult?.ToString();
+                  }
+              }
+              string context = request.StoryId != null ? "a post" : request.FileId != null ? "a file" : "a comment";
+              string eventText = $"{username ?? "Someone"} commented on {context}";
+              await UserEventController.InsertUserEventStatic(request.UserId, username, "comment", eventText, insertedId, "comment", _config, _log);
+          }
+          return Ok($"{insertedId} Comment Successfully Added");
 				}
 			}
 			catch (Exception ex)

--- a/maxhanna.Server/Controllers/DataContracts/UserEvents/UserEvent.cs
+++ b/maxhanna.Server/Controllers/DataContracts/UserEvents/UserEvent.cs
@@ -1,0 +1,14 @@
+namespace maxhanna.Server.Controllers.DataContracts.UserEvents
+{
+    public class UserEvent
+    {
+        public int Id { get; set; }
+        public int UserId { get; set; }
+        public string? Username { get; set; }
+        public string EventType { get; set; }
+        public string EventText { get; set; }
+        public int? ReferenceId { get; set; }
+        public string? ReferenceType { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/maxhanna.Server/Controllers/DataContracts/UserEvents/UserEventsRequest.cs
+++ b/maxhanna.Server/Controllers/DataContracts/UserEvents/UserEventsRequest.cs
@@ -1,0 +1,12 @@
+namespace maxhanna.Server.Controllers.DataContracts.UserEvents
+{
+    public class UserEventsRequest
+    {
+        public int UserId { get; set; }
+        public string? Username { get; set; }
+        public string EventType { get; set; }
+        public string EventText { get; set; }
+        public int? ReferenceId { get; set; }
+        public string? ReferenceType { get; set; }
+    }
+}

--- a/maxhanna.Server/Controllers/DigCraftController.cs
+++ b/maxhanna.Server/Controllers/DigCraftController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using MySqlConnector;
 using maxhanna.Server.Controllers.DataContracts.DigCraft;
+using maxhanna.Server.Controllers.DataContracts.UserEvents;
 using System.Collections.Concurrent;
 
 namespace maxhanna.Server.Controllers
@@ -3953,6 +3954,20 @@ var mobSpeed = t switch
                     var rows = await updCmd.ExecuteNonQueryAsync();
                     if (rows == 0)
                     {
+                        try
+                        {
+                            string? username = null;
+                            using (var nameCmd2 = new MySqlCommand("SELECT username FROM maxhanna.users WHERE id = @id LIMIT 1", conn))
+                            {
+                                nameCmd2.Parameters.AddWithValue("@id", req.UserId);
+                                var nameResult = await nameCmd2.ExecuteScalarAsync();
+                                username = nameResult?.ToString();
+                            }
+                            string eventText = $"{username ?? "Someone"} started playing DigCraft!";
+                            await UserEventController.InsertUserEventWithConnection(req.UserId, username, "digcraft_play", eventText, null, null, conn);
+                        }
+                        catch { }
+
                         // New player - find a random spawn point on a mountain (not over water)
                         int searchRadius = 256;
                         int maxAttempts = 500;
@@ -5128,12 +5143,26 @@ var mobSpeed = t switch
                 await reader.CloseAsync();
 
                 int expToLevel = GetExpForLevel(level + 1);
+                int originalLevel = level;
                 while (exp >= expToLevel)
                 {
                     exp -= expToLevel;
                     level++;
                     expToLevel = GetExpForLevel(level + 1);
                     _ = _log.Db($"Player {userId} leveled up to {level}!", userId, "DIGCRAFT", true);
+                }
+                if (level > originalLevel)
+                {
+                    try
+                    {
+                        using var nameCmd = new MySqlCommand("SELECT username FROM maxhanna.users WHERE id = @uid LIMIT 1", conn, tx);
+                        nameCmd.Parameters.AddWithValue("@uid", userId);
+                        var nameResult = await nameCmd.ExecuteScalarAsync();
+                        string? username = nameResult?.ToString();
+                        string eventText = $"{username ?? "Someone"} reached level {level} in DigCraft!";
+                        await UserEventController.InsertUserEventWithConnection(userId, username, "digcraft_levelup", eventText, level, "digcraft_level", conn, tx);
+                    }
+                    catch { }
                 }
 
                 using var updCmd = new MySqlCommand("UPDATE maxhanna.digcraft_players SET level = @level, exp = @exp WHERE user_id=@uid AND world_id=@wid", conn, tx);

--- a/maxhanna.Server/Controllers/EnderController.cs
+++ b/maxhanna.Server/Controllers/EnderController.cs
@@ -1,4 +1,5 @@
 using maxhanna.Server.Controllers.DataContracts.Ender;
+using maxhanna.Server.Controllers.DataContracts.UserEvents;
 using maxhanna.Server.Controllers.DataContracts.Users;
 using maxhanna.Server.Controllers.DataContracts.Files;
 using Microsoft.AspNetCore.Mvc;
@@ -2677,6 +2678,33 @@ namespace maxhanna.Server.Controllers
           killerNotifCmd.Parameters.AddWithValue("@KillerHeroId", killerId.Value);
           await killerNotifCmd.ExecuteNonQueryAsync();
         }
+        try
+        {
+            using (var nameCmd = new MySqlCommand("SELECT u.id, u.username FROM maxhanna.ender_hero v LEFT JOIN maxhanna.ender_hero kh ON kh.id = @KillerHeroId2 LEFT JOIN maxhanna.users u ON u.id = kh.user_id WHERE v.id = @VictimHeroId2 LIMIT 1", connection, transaction))
+            {
+                nameCmd.Parameters.AddWithValue("@VictimHeroId2", victimId);
+                nameCmd.Parameters.AddWithValue("@KillerHeroId2", killerId);
+                using (var rdr = await nameCmd.ExecuteReaderAsync())
+                {
+                    if (await rdr.ReadAsync())
+                    {
+                        int userId = rdr.IsDBNull(0) ? 0 : rdr.GetInt32(0);
+                        string? username = rdr.IsDBNull(1) ? null : rdr.GetString(1);
+                        if (userId > 0 && killerId.HasValue && killerId.Value != victimId)
+                        {
+                            string eventText = $"{username ?? "Someone"} shattered a lightcycle in Ender!";
+                            await UserEventController.InsertUserEventWithConnection(userId, username, "ender_kill", eventText, victimId, "ender_hero", connection, transaction);
+                        }
+                        else if (userId > 0)
+                        {
+                            string eventText = $"{username ?? "Someone"} crashed their lightcycle in Ender.";
+                            await UserEventController.InsertUserEventWithConnection(userId, username, "ender_death", eventText, victimId, "ender_hero", connection, transaction);
+                        }
+                    }
+                }
+            }
+        }
+        catch { }
       }
       catch (Exception ex)
       {

--- a/maxhanna.Server/Controllers/FavouriteController.cs
+++ b/maxhanna.Server/Controllers/FavouriteController.cs
@@ -1,5 +1,6 @@
 using FirebaseAdmin.Messaging;
 using maxhanna.Server.Controllers.DataContracts.Favourite;
+using maxhanna.Server.Controllers.DataContracts.UserEvents;
 using Microsoft.AspNetCore.Mvc;
 using MySqlConnector;
 
@@ -248,6 +249,26 @@ namespace maxhanna.Server.Controllers
 						int rowsAffected = await cmd.ExecuteNonQueryAsync();
 						if (rowsAffected > 0)
 						{
+							try
+							{
+								string? favName = null;
+								using (var nameCmd = new MySqlCommand("SELECT name FROM maxhanna.favourites WHERE id = @fid LIMIT 1", conn))
+								{
+									nameCmd.Parameters.AddWithValue("@fid", request.FavouriteId);
+									var result = await nameCmd.ExecuteScalarAsync();
+									favName = result?.ToString();
+								}
+								string? username = null;
+								using (var nameCmd2 = new MySqlCommand("SELECT username FROM maxhanna.users WHERE id = @uid LIMIT 1", conn))
+								{
+									nameCmd2.Parameters.AddWithValue("@uid", request.UserId);
+									var result2 = await nameCmd2.ExecuteScalarAsync();
+									username = result2?.ToString();
+								}
+								string eventText = $"{username ?? "Someone"} favourited {(favName ?? "a link")}";
+								await UserEventController.InsertUserEventWithConnection(request.UserId, username, "favourite_add", eventText, request.FavouriteId, "favourite", conn);
+							}
+							catch { }
 							return Ok("Favourite added successfully.");
 						}
 						else

--- a/maxhanna.Server/Controllers/FileController.cs
+++ b/maxhanna.Server/Controllers/FileController.cs
@@ -1,9 +1,8 @@
-﻿using FirebaseAdmin.Messaging;
+using FirebaseAdmin.Messaging;
 using maxhanna.Server.Controllers.DataContracts;
 using maxhanna.Server.Controllers.DataContracts.Files;
-using maxhanna.Server.Controllers.DataContracts.Topics;
+using maxhanna.Server.Controllers.DataContracts.UserEvents;
 using maxhanna.Server.Controllers.DataContracts.Users;
-using maxhanna.Server.Controllers.DataContracts.Social;
 using Microsoft.AspNetCore.Mvc;
 using MySqlConnector;
 using Newtonsoft.Json;
@@ -2240,6 +2239,23 @@ namespace maxhanna.Server.Controllers
           }
         }
         string message = $"Uploaded {uploaded.Count} files. Conflicts: {conflicts}.";
+        if (uploaded.Count > 0 && userId != null)
+        {
+            string? username = null;
+            using (var nameConn = new MySqlConnection(_connectionString))
+            {
+                await nameConn.OpenAsync();
+                using (var nameCmd = new MySqlCommand("SELECT username FROM maxhanna.users WHERE id = @id LIMIT 1", nameConn))
+                {
+                    nameCmd.Parameters.AddWithValue("@id", userId.Value);
+                    var result = await nameCmd.ExecuteScalarAsync();
+                    username = result?.ToString();
+                }
+            }
+            string folder = uploadDirectory?.Replace("/", " ").Trim() ?? "";
+            string eventText = $"{username ?? "Someone"} uploaded {uploaded.Count} file{(uploaded.Count > 1 ? "s" : "")} to {folder}";
+            await UserEventController.InsertUserEventStatic(userId.Value, username, "file_upload", eventText, uploaded[0].Id, "file", _config, _log);
+        }
         return Ok(uploaded);
       }
       catch (Exception ex)

--- a/maxhanna.Server/Controllers/MetaController.cs
+++ b/maxhanna.Server/Controllers/MetaController.cs
@@ -1,4 +1,5 @@
 using maxhanna.Server.Controllers.DataContracts.Meta;
+using maxhanna.Server.Controllers.DataContracts.UserEvents;
 using maxhanna.Server.Controllers.DataContracts.Users;
 using maxhanna.Server.Controllers.DataContracts.Files;
 using Microsoft.AspNetCore.Mvc;
@@ -2048,6 +2049,22 @@ namespace maxhanna.Server.Controllers
 			if (winnerBot?.HeroId > 0)
 			{
 				await AwardExpToPlayer(winnerBot, deadBot, connection, transaction);
+				try
+				{
+					string? username = null;
+					using (var nameCmd3 = new MySqlCommand("SELECT u.username FROM maxhanna.users u JOIN maxhanna.meta_hero mh ON mh.user_id = u.id JOIN maxhanna.meta_bot mb ON mb.hero_id = mh.id WHERE mb.id = @botId LIMIT 1", connection, transaction))
+					{
+						nameCmd3.Parameters.AddWithValue("@botId", winnerBot.Id);
+						var nameResult = await nameCmd3.ExecuteScalarAsync();
+						username = nameResult?.ToString();
+					}
+					if (!string.IsNullOrEmpty(username))
+					{
+						string eventText = $"{username} defeated a bot in Meta-Bots!";
+						await UserEventController.InsertUserEventWithConnection(0, username, "meta_encounter", eventText, deadBot.Id, "meta_bot", connection, transaction);
+					}
+				}
+				catch { }
 			}
 		}
 

--- a/maxhanna.Server/Controllers/RomController.cs
+++ b/maxhanna.Server/Controllers/RomController.cs
@@ -350,6 +350,20 @@ namespace maxhanna.Server.Controllers
             }
           }
         }
+        try
+        {
+            string? username = null;
+            using (var nameCmd = new MySqlCommand("SELECT username FROM maxhanna.users WHERE id = @id LIMIT 1", connection))
+            {
+                nameCmd.Parameters.AddWithValue("@id", userId);
+                var nameResult = await nameCmd.ExecuteScalarAsync();
+                username = nameResult?.ToString();
+            }
+            string romDisplay = System.IO.Path.GetFileNameWithoutExtension(romFileName);
+            string eventText = $"{username ?? "Someone"} is playing {romDisplay} on the emulator";
+            await UserEventController.InsertUserEventStatic(userId, username, "emulator_play", eventText, null, null, _config, _log);
+        }
+        catch { }
       }
       catch (Exception ex)
       {

--- a/maxhanna.Server/Controllers/SocialController.cs
+++ b/maxhanna.Server/Controllers/SocialController.cs
@@ -2,10 +2,8 @@ using FirebaseAdmin.Messaging;
 using HtmlAgilityPack;
 using maxhanna.Server.Controllers.DataContracts;
 using maxhanna.Server.Controllers.DataContracts.Files;
-using maxhanna.Server.Controllers.DataContracts.Metadata;
 using maxhanna.Server.Controllers.DataContracts.Social;
-using maxhanna.Server.Controllers.DataContracts.Topics;
-using maxhanna.Server.Controllers.DataContracts.Users;
+using maxhanna.Server.Controllers.DataContracts.UserEvents;
 using Microsoft.AspNetCore.Mvc;
 using MySqlConnector;
 using System.Data;
@@ -1513,6 +1511,19 @@ namespace maxhanna.Server.Controllers
               }
 
               await AppendToSitemapAsync(storyId);
+
+              if (request.userId != null)
+              {
+                  string? username = null;
+                  using (var nameCmd = new MySqlCommand("SELECT username FROM maxhanna.users WHERE id = @id LIMIT 1", conn))
+                  {
+                      nameCmd.Parameters.AddWithValue("@id", request.userId);
+                      var nameResult = await nameCmd.ExecuteScalarAsync();
+                      username = nameResult?.ToString();
+                  }
+                  string eventText = $"{username ?? "Someone"} posted{(request.story.ProfileUserId.HasValue && request.story.ProfileUserId != 0 ? " on a profile" : "")}";
+                  await UserEventController.InsertUserEventWithConnection(request.userId.Value, username, "story_post", eventText, storyId, "story", conn);
+              }
 
               // Return the storyId in the response
               return Ok(new { StoryId = storyId, Message = "Story posted successfully." });

--- a/maxhanna.Server/Controllers/UserEventController.cs
+++ b/maxhanna.Server/Controllers/UserEventController.cs
@@ -1,0 +1,157 @@
+using maxhanna.Server.Controllers.DataContracts.UserEvents;
+using Microsoft.AspNetCore.Mvc;
+using MySqlConnector;
+
+namespace maxhanna.Server.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class UserEventController : ControllerBase
+    {
+        private readonly IConfiguration _config;
+        private readonly Log _log;
+
+        public UserEventController(IConfiguration config, Log log)
+        {
+            _config = config;
+            _log = log;
+        }
+
+        [HttpGet(Name = "GetUserEvents")]
+        public async Task<IActionResult> GetUserEvents([FromQuery] int limit = 50)
+        {
+            try
+            {
+                using (var conn = new MySqlConnection(_config.GetValue<string>("ConnectionStrings:maxhanna")))
+                {
+                    await conn.OpenAsync();
+                    string sql = @"
+                        SELECT id, user_id, username, event_type, event_text, reference_id, reference_type, created_at
+                        FROM maxhanna.user_events
+                        WHERE created_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 2 DAY)
+                        ORDER BY created_at DESC
+                        LIMIT @Limit;";
+
+                    using (var cmd = new MySqlCommand(sql, conn))
+                    {
+                        cmd.Parameters.AddWithValue("@Limit", limit);
+                        using (var reader = await cmd.ExecuteReaderAsync())
+                        {
+                            var events = new List<UserEvent>();
+                            while (await reader.ReadAsync())
+                            {
+                                events.Add(new UserEvent
+                                {
+                                    Id = reader.GetInt32("id"),
+                                    UserId = reader.GetInt32("user_id"),
+                                    Username = reader.IsDBNull(reader.GetOrdinal("username")) ? null : reader.GetString("username"),
+                                    EventType = reader.GetString("event_type"),
+                                    EventText = reader.GetString("event_text"),
+                                    ReferenceId = reader.IsDBNull(reader.GetOrdinal("reference_id")) ? null : reader.GetInt32("reference_id"),
+                                    ReferenceType = reader.IsDBNull(reader.GetOrdinal("reference_type")) ? null : reader.GetString("reference_type"),
+                                    CreatedAt = reader.GetDateTime("created_at")
+                                });
+                            }
+                            return Ok(events);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _ = _log.Db("Error fetching user events: " + ex.Message, null, "USEREVENT", true);
+                return StatusCode(500, "An error occurred while fetching user events.");
+            }
+        }
+
+        [HttpPost("/UserEvent/Insert", Name = "InsertUserEvent")]
+        public async Task<IActionResult> InsertUserEvent([FromBody] UserEventsRequest request)
+        {
+            if (request.UserId == 0 || string.IsNullOrEmpty(request.EventType) || string.IsNullOrEmpty(request.EventText))
+                return BadRequest("UserId, EventType, and EventText are required.");
+
+            try
+            {
+                using (var conn = new MySqlConnection(_config.GetValue<string>("ConnectionStrings:maxhanna")))
+                {
+                    await conn.OpenAsync();
+                    string sql = @"
+                        INSERT INTO maxhanna.user_events (user_id, username, event_type, event_text, reference_id, reference_type, created_at)
+                        VALUES (@UserId, @Username, @EventType, @EventText, @ReferenceId, @ReferenceType, UTC_TIMESTAMP());";
+
+                    using (var cmd = new MySqlCommand(sql, conn))
+                    {
+                        cmd.Parameters.AddWithValue("@UserId", request.UserId);
+                        cmd.Parameters.AddWithValue("@Username", request.Username ?? (object)DBNull.Value);
+                        cmd.Parameters.AddWithValue("@EventType", request.EventType);
+                        cmd.Parameters.AddWithValue("@EventText", request.EventText);
+                        cmd.Parameters.AddWithValue("@ReferenceId", request.ReferenceId ?? (object)DBNull.Value);
+                        cmd.Parameters.AddWithValue("@ReferenceType", request.ReferenceType ?? (object)DBNull.Value);
+                        await cmd.ExecuteNonQueryAsync();
+                    }
+                }
+                return Ok(true);
+            }
+            catch (Exception ex)
+            {
+                _ = _log.Db("Error inserting user event: " + ex.Message, request.UserId, "USEREVENT", true);
+                return StatusCode(500, "An error occurred while inserting user event.");
+            }
+        }
+
+        public static async Task InsertUserEventStatic(int userId, string? username, string eventType, string eventText, int? referenceId, string? referenceType, IConfiguration config, Log log)
+        {
+            try
+            {
+                using (var conn = new MySqlConnection(config.GetValue<string>("ConnectionStrings:maxhanna")))
+                {
+                    await conn.OpenAsync();
+                    string sql = @"
+                        INSERT INTO maxhanna.user_events (user_id, username, event_type, event_text, reference_id, reference_type, created_at)
+                        VALUES (@UserId, @Username, @EventType, @EventText, @ReferenceId, @ReferenceType, UTC_TIMESTAMP());";
+
+                    using (var cmd = new MySqlCommand(sql, conn))
+                    {
+                        cmd.Parameters.AddWithValue("@UserId", userId);
+                        cmd.Parameters.AddWithValue("@Username", username ?? (object)DBNull.Value);
+                        cmd.Parameters.AddWithValue("@EventType", eventType);
+                        cmd.Parameters.AddWithValue("@EventText", eventText);
+                        cmd.Parameters.AddWithValue("@ReferenceId", referenceId ?? (object)DBNull.Value);
+                        cmd.Parameters.AddWithValue("@ReferenceType", referenceType ?? (object)DBNull.Value);
+                        await cmd.ExecuteNonQueryAsync();
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _ = log.Db("Error inserting user event (static): " + ex.Message, userId, "USEREVENT", true);
+            }
+        }
+
+        public static async Task InsertUserEventWithConnection(int userId, string? username, string eventType, string eventText, int? referenceId, string? referenceType, MySqlConnection conn, MySqlTransaction? transaction = null)
+        {
+            try
+            {
+                string sql = @"
+                    INSERT INTO maxhanna.user_events (user_id, username, event_type, event_text, reference_id, reference_type, created_at)
+                    VALUES (@UserId, @Username, @EventType, @EventText, @ReferenceId, @ReferenceType, UTC_TIMESTAMP());";
+
+                using (var cmd = new MySqlCommand(sql, conn))
+                {
+                    if (transaction != null)
+                        cmd.Transaction = transaction;
+                    cmd.Parameters.AddWithValue("@UserId", userId);
+                    cmd.Parameters.AddWithValue("@Username", username ?? (object)DBNull.Value);
+                    cmd.Parameters.AddWithValue("@EventType", eventType);
+                    cmd.Parameters.AddWithValue("@EventText", eventText);
+                    cmd.Parameters.AddWithValue("@ReferenceId", referenceId ?? (object)DBNull.Value);
+                    cmd.Parameters.AddWithValue("@ReferenceType", referenceType ?? (object)DBNull.Value);
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+            catch (Exception)
+            {
+            }
+        }
+    }
+}

--- a/maxhanna.Server/Services/NewsService.cs
+++ b/maxhanna.Server/Services/NewsService.cs
@@ -1,5 +1,6 @@
 using maxhanna.Server.Controllers.DataContracts.News;
 using maxhanna.Server.Controllers.DataContracts.Metadata;
+using maxhanna.Server.Controllers.DataContracts.UserEvents;
 using System.Web;
 using System.Net;
 using MySqlConnector;
@@ -1094,6 +1095,13 @@ Posted by user @{topMeme.Username}<br><small>Daily top memes are selected based 
     fileCmd.Parameters.AddWithValue("@storyId", storyId);
     fileCmd.Parameters.AddWithValue("@fileId", fileId);
     await fileCmd.ExecuteNonQueryAsync();
+
+    try
+    {
+        string eventText = $"Top Daily Meme posted!";
+        await UserEventController.InsertUserEventWithConnection(memeServiceAccountNo, "BugHosted", "daily_meme", eventText, fileId, "file", conn, transaction);
+    }
+    catch { }
   }
   private string GetMostFrequentWord(ArticlesResult? topArticlesResult, out List<(Article Article, List<string> Tokens)> articleTokenMap)
   {

--- a/maxhanna.Server/Services/SystemBackgroundService.cs
+++ b/maxhanna.Server/Services/SystemBackgroundService.cs
@@ -217,6 +217,7 @@ namespace maxhanna.Server.Services
       await _newsService.CreateDailyNewsStoryAsync();
       await CleanupOldFavourites();
       await DeleteExpiredPasswordResetTokens();
+      await DeleteOldUserEvents();
       await _log.BackupDatabase();
     }
 
@@ -2129,6 +2130,27 @@ namespace maxhanna.Server.Services
       catch (Exception ex)
       {
         _ = _log.Db("DeleteExpiredPasswordResetTokens failure: " + ex.Message, null, "SYSTEM", true);
+      }
+    }
+
+    private async Task DeleteOldUserEvents()
+    {
+      try
+      {
+        await using var conn = new MySqlConnection(_connectionString);
+        await conn.OpenAsync();
+        const string sql = @"DELETE FROM maxhanna.user_events
+          WHERE created_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL 2 DAY);";
+        await using var cmd = new MySqlCommand(sql, conn);
+        int deleted = Convert.ToInt32(await cmd.ExecuteNonQueryAsync());
+        if (deleted > 0)
+        {
+          _ = _log.Db($"DeleteOldUserEvents removed {deleted} old event rows", null, "SYSTEM", outputToConsole: true);
+        }
+      }
+      catch (Exception ex)
+      {
+        _ = _log.Db("DeleteOldUserEvents failure: " + ex.Message, null, "SYSTEM", true);
       }
     }
 

--- a/maxhanna.client/src/app/app.module.ts
+++ b/maxhanna.client/src/app/app.module.ts
@@ -103,6 +103,7 @@ import { ProfileWidgetsComponent } from './profile-widgets/profile-widgets.compo
 import { BonesHighScoresComponent } from './bones-high-scores/bones-high-scores.component';
 import { NewUsersComponent } from './new-users/new-users.component';
 import { OnlineUsersComponent } from './online-users/online-users.component';
+import { UserEventsComponent } from './user-events/user-events.component';
 import { CurrentlyPlayingComponent } from './currently-playing/currently-playing.component';
 import { EmulatorComponent } from './emulator/emulator.component';
 import { TitleBarComponent } from './title-bar/title-bar.component';
@@ -197,6 +198,7 @@ import { GlobeViewComponent } from './globe-view/globe-view.component';
     EmulatorComponent,
     NewUsersComponent,
     OnlineUsersComponent,
+    UserEventsComponent,
     CurrentlyPlayingComponent,
     TitleBarComponent,
     RatingStarsComponent,

--- a/maxhanna.client/src/app/profile-widgets/profile-widgets.component.html
+++ b/maxhanna.client/src/app/profile-widgets/profile-widgets.component.html
@@ -22,4 +22,7 @@
   <div class="widget" id="onlineusers" [attr.data-order]="(availabilityOnlineUsers ? 0 : 1)">
     <app-online-users (hasData)="onChildHasData('onlineusers',$event)" [inputtedParentRef]="parentRef"></app-online-users>
   </div>
+  <div class="widget" id="userevents" [attr.data-order]="(availabilityUserEvents ? 0 : 1)">
+    <app-user-events (hasData)="onChildHasData('userevents',$event)" [inputtedParentRef]="parentRef"></app-user-events>
+  </div>
 </div>

--- a/maxhanna.client/src/app/profile-widgets/profile-widgets.component.ts
+++ b/maxhanna.client/src/app/profile-widgets/profile-widgets.component.ts
@@ -5,7 +5,8 @@ import { WordlerHighScoresComponent } from '../wordler-high-scores/wordler-high-
 import { DailyMusicComponent } from '../daily-music/daily-music.component';
 import { NewUsersComponent } from '../new-users/new-users.component';
 import { OnlineUsersComponent } from '../online-users/online-users.component';
-
+import { UserEventsComponent } from '../user-events/user-events.component';
+ 
 @Component({
   selector: 'app-profile-widgets',
   templateUrl: './profile-widgets.component.html',
@@ -22,6 +23,7 @@ export class ProfileWidgetsComponent implements AfterViewInit {
   availabilityMusic: boolean = false;
   availabilityNewUsers: boolean = false;
   availabilityOnlineUsers: boolean = false;
+  availabilityUserEvents: boolean = false;
   availabilityCurrentlyPlaying: boolean = false;
   @ViewChildren(MastermindScoresComponent) mastermindComponents!: QueryList<MastermindScoresComponent>;
   @ViewChildren(EnderHighScoresComponent) enderComponents!: QueryList<EnderHighScoresComponent>;
@@ -29,6 +31,7 @@ export class ProfileWidgetsComponent implements AfterViewInit {
   @ViewChildren(DailyMusicComponent) musicComponents!: QueryList<DailyMusicComponent>;
   @ViewChildren(NewUsersComponent) newUsersComponents!: QueryList<NewUsersComponent>;
   @ViewChildren(OnlineUsersComponent) onlineUsersComponents!: QueryList<OnlineUsersComponent>;
+  @ViewChildren(UserEventsComponent) userEventsComponents!: QueryList<UserEventsComponent>;
 
   orderedKeys: string[] = [];
   // track hasData values keyed by component id
@@ -48,6 +51,7 @@ export class ProfileWidgetsComponent implements AfterViewInit {
       case 'music': this.availabilityMusic = has; break;
       case 'newusers': this.availabilityNewUsers = has; break;
       case 'onlineusers': this.availabilityOnlineUsers = has; break;
+      case 'userevents': this.availabilityUserEvents = has; break;
     }
     this.reorder();
   }

--- a/maxhanna.client/src/app/user-events/user-events.component.css
+++ b/maxhanna.client/src/app/user-events/user-events.component.css
@@ -1,0 +1,29 @@
+.user-events-component { width: 100%; }
+.userEventsTitle {
+    display: flex;
+    align-items: center;
+    padding: .5rem 0;
+    font-weight: 600;
+    border-bottom: 1px solid var(--main-border-color);
+    margin-bottom: 1rem;
+    cursor: pointer;
+    text-decoration: underline;
+}
+.eventRow {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 3px 0;
+    font-size: 0.85rem;
+    line-height: 1.3;
+}
+.eventIcon { flex-shrink: 0; font-size: 0.9rem; }
+.eventText { flex: 1; word-break: break-word; }
+.eventTime {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    color: var(--main-text-color);
+    opacity: 0.6;
+    white-space: nowrap;
+    margin-left: auto;
+}

--- a/maxhanna.client/src/app/user-events/user-events.component.html
+++ b/maxhanna.client/src/app/user-events/user-events.component.html
@@ -1,0 +1,15 @@
+<div class="user-events-component">
+  <div class="userEventsTitle popupPanelTitle" *ngIf="loading || events?.length">Recent Activity:</div>
+  <div *ngIf="loading" class="loading">Loading events...</div>
+  <div *ngIf="loadError" class="error">{{ loadError }}</div>
+  <div *ngIf="events && events.length > 0">
+    <div *ngFor="let e of events" class="eventRow">
+      <span class="eventIcon">{{ getEventIcon(e.eventType) }}</span>
+      <span class="eventText">{{ e.eventText }}</span>
+      <span class="eventTime" [title]="e.createdAt | date: 'y/MM/d HH:mm'">{{ e.createdAt | timeSince:'minute':true }}</span>
+    </div>
+  </div>
+  <div *ngIf="!loading && (!events || events.length == 0)">
+    No recent activity.
+  </div>
+</div>

--- a/maxhanna.client/src/app/user-events/user-events.component.ts
+++ b/maxhanna.client/src/app/user-events/user-events.component.ts
@@ -1,0 +1,62 @@
+import { AfterViewInit, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ChildComponent } from '../child.component';
+import { UserEvent } from '../../services/datacontracts/user-event/user-event';
+import { UserEventService } from '../../services/user-event.service';
+import { AppComponent } from '../app.component';
+
+@Component({
+  selector: 'app-user-events',
+  templateUrl: './user-events.component.html',
+  styleUrl: './user-events.component.css',
+  standalone: false
+})
+export class UserEventsComponent extends ChildComponent implements OnInit, AfterViewInit {
+  events: UserEvent[] = [];
+  loadError: string | null = null;
+  @Input() inputtedParentRef?: AppComponent;
+  @Output() hasData = new EventEmitter<boolean>();
+  loading = false;
+
+  constructor(private userEventService: UserEventService) { super(); }
+
+  async ngOnInit() {
+    await this.loadEvents();
+  }
+  ngAfterViewInit() { }
+
+  async loadEvents() {
+    this.loadError = null;
+    this.loading = true;
+    try {
+      this.events = await this.userEventService.getUserEvents(50);
+    } catch (e) {
+      console.error('Failed to load user events', e);
+      this.events = [];
+      this.loadError = 'Failed to load events.';
+    } finally {
+      this.loading = false;
+      try { this.hasData.emit((this.events?.length ?? 0) > 0); } catch { }
+    }
+  }
+
+  getEventIcon(eventType: string): string {
+    switch (eventType) {
+      case 'file_upload': return '📁';
+      case 'story_post': return '📝';
+      case 'comment': return '💬';
+      case 'bones_kill': return '⚔️';
+      case 'bones_death': return '💀';
+      case 'ender_kill': return '🏍️';
+      case 'ender_death': return '💥';
+      case 'digcraft_play': return '⛏️';
+      case 'emulator_play': return '🎮';
+      case 'nexus_play': return '🐛';
+      case 'meta_encounter': return '🤖';
+      case 'daily_meme': return '😂';
+      case 'favourite_add': return '⭐';
+      case 'digcraft_levelup': return '⬆️';
+      case 'trophy': return '🏆';
+      default: return '📌';
+    }
+  }
+}

--- a/maxhanna.client/src/services/datacontracts/user-event/user-event.ts
+++ b/maxhanna.client/src/services/datacontracts/user-event/user-event.ts
@@ -1,0 +1,10 @@
+export interface UserEvent {
+  id: number;
+  userId: number;
+  username?: string;
+  eventType: string;
+  eventText: string;
+  referenceId?: number;
+  referenceType?: string;
+  createdAt: Date;
+}

--- a/maxhanna.client/src/services/user-event.service.ts
+++ b/maxhanna.client/src/services/user-event.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import { UserEvent } from './datacontracts/user-event/user-event';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserEventService {
+  constructor() { }
+
+  async getUserEvents(limit: number = 50): Promise<UserEvent[]> {
+    try {
+      const response = await fetch(`/userevent?limit=${limit}`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (response.status === 404) return [];
+      if (!response.ok) return [];
+      return await response.json() as UserEvent[];
+    } catch (error) {
+      console.error('Error fetching user events:', error);
+      return [];
+    }
+  }
+
+  async insertUserEvent(userId: number, username: string | undefined, eventType: string, eventText: string, referenceId?: number, referenceType?: string): Promise<boolean> {
+    try {
+      const response = await fetch('/userevent/insert', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId,
+          username,
+          eventType,
+          eventText,
+          referenceId,
+          referenceType
+        }),
+      });
+      return response.ok;
+    } catch (error) {
+      console.error('Error inserting user event:', error);
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements a `user_events` database table and UI component to track and display site-wide user activity in real-time. The feed shows recent actions like file uploads, posts, comments, game kills, and level-ups, displayed on the public user page (under active users).

## Changes

### Server Side
- **New DB table** `maxhanna.user_events` -- stores events with `user_id`, `username`, `event_type`, `event_text`, `reference_id`, `reference_type`, and `created_at`. Indexed on creation time for fast retrieval.
- **New `UserEventController`** -- `GET /userevent` returns recent events (last 48h, newest first), `POST /userevent/insert` inserts a new event. Also exposes static helpers for inline insertion from other controllers.
- **Event insertion at 12 source locations:**
  - `FileController` -- when files are uploaded to any directory
  - `SocialController` -- when a story/post is created
  - `CommentController` -- when a comment is posted
  - `FavouriteController` -- when a user favourites a link
  - `BonesController` -- on PvP kills and deaths
  - `EnderController` -- on lightcycle kills and crashes
  - `DigCraftController` -- on new player join and level-ups
  - `RomController` -- on emulator ROM selection
  - `MetaController` -- on bot encounter defeats
  - `NewsService` -- when the daily top meme is posted
- **Cleanup** -- `SystemBackgroundService` deletes events older than 48 hours in its daily maintenance cycle

### Client Side
- **New `UserEventsComponent`** -- Angular component showing a scrollable activity feed with event-type icons and relative timestamps. Follows the same pattern as the existing `OnlineUsersComponent`.
- **New `UserEventService`** -- Angular service to fetch events via `GET /userevent`
- **Integrated into `ProfileWidgetsComponent`** -- the event feed appears in the profile-widgets sidebar, ordered dynamically alongside other widgets

### Event Types
| Event Type | Icon | Source |
|---|---|---|
| `file_upload` | :file_folder: | File uploads |
| `story_post` | :memo: | Social posts |
| `comment` | :speech_balloon: | Comments |
| `favourite_add` | :star: | Favourite links |
| `bones_kill` / `bones_death` | :crossed_swords: / :skull: | Bones PvP |
| `ender_kill` / `ender_death` | :motorcycle: / :boom: | Ender lightcycle battles |
| `digcraft_play` / `digcraft_levelup` | :pick: / :arrow_up: | DigCraft join & leveling |
| `emulator_play` | :video_game: | ROM emulator |
| `meta_encounter` | :robot: | Meta bot defeats |
| `daily_meme` | :joy: | Daily top meme |

## Why

This provides a public, transparent activity feed showing what's happening across the site, encouraging community engagement and making the platform feel alive for anonymous visitors.

This PR was written using [Vibe Kanban](https://vibekanban.com)
