### PR TITLE
Add ping clustering and user info popup to globe component (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/globe/globe.component.css
+++ b/maxhanna.client/src/app/globe/globe.component.css
@@ -597,6 +597,135 @@
   background: #1a5ed8;
 }
 
+/* ---- Cluster Popup Panel ---- */
+.cluster-popup-backdrop {
+  position: fixed;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  background: rgba(0,0,0,0.5);
+  z-index: 999;
+}
+
+.cluster-popup-panel.popupPanel {
+  max-width: 420px;
+  width: 90vw;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.cluster-pings-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.cluster-ping-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: rgba(30, 30, 45, 0.6);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.cluster-ping-item:hover {
+  background: rgba(40, 40, 60, 0.8);
+}
+
+.cluster-ping-icon {
+  font-size: 18px;
+  flex-shrink: 0;
+  width: 28px;
+  text-align: center;
+}
+
+.cluster-ping-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.cluster-ping-label {
+  font-weight: 600;
+  color: #fff;
+  font-size: 13px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cluster-ping-source {
+  color: #888;
+  font-size: 11px;
+}
+
+/* ---- User Popup Panel ---- */
+.user-popup-backdrop {
+  position: fixed;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  background: rgba(0,0,0,0.5);
+  z-index: 999;
+}
+
+.user-popup-panel.popupPanel {
+  max-width: 360px;
+  width: 90vw;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.user-popup-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+}
+
+.user-popup-details {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 8px;
+}
+
+.user-popup-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+}
+
+.user-popup-row span:last-child {
+  color: #fff;
+  text-align: right;
+}
+
+.user-popup-label {
+  color: #888;
+  flex-shrink: 0;
+}
+
+.user-popup-profile-btn {
+  padding: 10px 24px;
+  background: #2a6ef0;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  align-self: center;
+}
+
+.user-popup-profile-btn:hover {
+  background: #1a5ed8;
+}
+
 @media (max-width: 667px) {
   .news-popup-panel.popupPanel {
     width: calc(100vw - 50px);

--- a/maxhanna.client/src/app/globe/globe.component.html
+++ b/maxhanna.client/src/app/globe/globe.component.html
@@ -146,4 +146,37 @@
     <p class="news-popup-date" *ngIf="selectedNewsPin.createdAt">Published: {{ selectedNewsPin.createdAt | date:'mediumDate' }}</p>
     <button type="button" class="news-popup-open-btn" (click)="openNewsArticleInNewTab()">Open Article in New Tab</button>
   </div>
+
+  <!-- Cluster Popup (multiple pings at same location) -->
+  <div class="cluster-popup-backdrop" *ngIf="showClusterPopup" (click)="closeClusterPopup()"></div>
+  <div class="popupPanel cluster-popup-panel" *ngIf="showClusterPopup && selectedClusterPings.length > 0">
+    <div class="popupPanelTitle">Pings at {{ clusterLocationLabel }}</div>
+    <button class="close-btn" (click)="closeClusterPopup()">×</button>
+    <div class="cluster-pings-list">
+      <div class="cluster-ping-item" *ngFor="let ping of selectedClusterPings" (click)="onClusterPingClick(ping)">
+        <span class="cluster-ping-icon" [class.news-icon]="ping.source === 'news'" [class.user-icon]="ping.source === 'user'" [class.story-icon]="ping.source === 'story'">
+          {{ ping.source === 'news' ? '📰' : ping.source === 'user' ? '👤' : ping.source === 'story' ? '📖' : '📍' }}
+        </span>
+        <div class="cluster-ping-info">
+          <div class="cluster-ping-label">{{ ping.label }}</div>
+          <div class="cluster-ping-source">{{ ping.source === 'news' ? 'News Article' : ping.source === 'user' ? 'User' : ping.source === 'story' ? 'Story' : 'Ping' }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- User Info Popup -->
+  <div class="user-popup-backdrop" *ngIf="showUserPopup" (click)="closeUserPopup()"></div>
+  <div class="popupPanel user-popup-panel" *ngIf="showUserPopup && selectedUser">
+    <div class="popupPanelTitle">User Info</div>
+    <button class="close-btn" (click)="closeUserPopup()">×</button>
+    <div class="user-popup-content">
+      <app-user-tag [user]="selectedUser" [preventOpenProfile]="true"></app-user-tag>
+      <div class="user-popup-details">
+        <div class="user-popup-row"><span class="user-popup-label">Username:</span><span>{{ selectedUser.username }}</span></div>
+        <div class="user-popup-row"><span class="user-popup-label">Location:</span><span>{{ formatLocationLabel(selectedUser.city, selectedUser.country) }}</span></div>
+      </div>
+      <button type="button" class="user-popup-profile-btn" (click)="openUserProfile(selectedUser)">Open Profile</button>
+    </div>
+  </div>
 </div>

--- a/maxhanna.client/src/app/globe/globe.component.ts
+++ b/maxhanna.client/src/app/globe/globe.component.ts
@@ -198,6 +198,11 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   showFlightDetail = false;
   selectedNewsPin: NewsPin | null = null;
   showNewsPopup = false;
+  showClusterPopup = false;
+  selectedClusterPings: ResolvedGlobePing[] = [];
+  clusterLocationLabel = '';
+  showUserPopup = false;
+  selectedUser: UserWithLocation | null = null;
   flightArcs: Arc[] = [];
 
   // ---- coordinates display -------------------------------------------------
@@ -522,6 +527,40 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   openNewsArticleInNewTab(): void {
     if (this.selectedNewsPin?.articleUrl) {
       window.open(this.selectedNewsPin.articleUrl, '_blank');
+    }
+  }
+
+  closeClusterPopup(): void {
+    this.showClusterPopup = false;
+    this.selectedClusterPings = [];
+    this.clusterLocationLabel = '';
+  }
+
+  onClusterPingClick(ping: ResolvedGlobePing): void {
+    if (ping.source === 'news' && ping.newsPin) {
+      this.selectedNewsPin = ping.newsPin;
+      this.showNewsPopup = true;
+      this.showClusterPopup = false;
+      return;
+    }
+    if (ping.source === 'user' && ping.user) {
+      this.selectedUser = ping.user;
+      this.showUserPopup = true;
+      this.showClusterPopup = false;
+      return;
+    }
+    this.focusPing(ping);
+    this.closeClusterPopup();
+  }
+
+  closeUserPopup(): void {
+    this.showUserPopup = false;
+    this.selectedUser = null;
+  }
+
+  openUserProfile(user: UserWithLocation): void {
+    if (user.id) {
+      window.open(`https://bughosted.com/User/${user.id}`, '_blank');
     }
   }
 
@@ -1740,11 +1779,33 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     if (this.dragMoved) return;
     const ping = this.findPingAtEvent(e);
     if (!ping) return;
+
+    const allPings = this.getAllPings();
+    const sameLocationPings = allPings.filter(p =>
+      Math.abs(p.lat - ping.lat) < 0.001 && Math.abs(p.lon - ping.lon) < 0.001
+    );
+
+    if (sameLocationPings.length > 1) {
+      this.selectedClusterPings = sameLocationPings;
+      this.clusterLocationLabel = ping.label;
+      this.showClusterPopup = true;
+      this.focusPing(ping);
+      return;
+    }
+
     if (ping.source === 'news' && ping.newsPin) {
       this.selectedNewsPin = ping.newsPin;
       this.showNewsPopup = true;
       return;
     }
+
+    if (ping.source === 'user' && ping.user) {
+      this.selectedUser = ping.user;
+      this.showUserPopup = true;
+      this.focusPing(ping);
+      return;
+    }
+
     const pingData = ping.data as any;
     if (pingData?.type === 'flight') {
       this.onFlightClick(ping);


### PR DESCRIPTION
## Summary

- Added ping clustering: when multiple pings (news, user, story, or custom) share the same location, clicking any of them opens a cluster popup panel listing all pings at that location, allowing the user to select the specific one to open its detail panel
- Added user info popup: clicking a user ping (when not clustered) now opens a dedicated panel displaying the user's info with the pp-user-tag component and an Open Profile button that navigates to their profile URL
- Added CSS styles for both the cluster popup panel and user info popup panel, following the existing popup panel styling patterns

## What Changed

### globe.component.ts
- Added state properties: showClusterPopup, selectedClusterPings, clusterLocationLabel, showUserPopup, selectedUser
- Modified onClick(): detects multiple pings within 0.001° of each other, shows cluster popup or user popup accordingly
- Added methods: closeClusterPopup(), onClusterPingClick(), closeUserPopup(), openUserProfile()

### globe.component.html
- Added cluster popup panel with scrollable list of pings at the selected location
- Added user info popup panel with app-user-tag, location details, and Open Profile button

### globe.component.css
- Added .cluster-popup-backdrop, .cluster-popup-panel, .cluster-ping-item, and related styles
- Added .user-popup-backdrop, .user-popup-panel, .user-popup-content, and related styles

## Implementation Details

- Clustering threshold: 0.001 degrees (~110 meters) for grouping pings at the same exact location
- Cluster items are color/icon-coded by source: news (📰), user (👤), story (📖)
- The cluster popup is dismissible by clicking the backdrop or the close button
- Once a user navigates a cluster item, the cluster popup closes and the target detail panel opens
- This prevents the issue where multiple pings stacked at the same coordinate are impossible to individually interact with