### PR TITLE
Skip save confirmation popup when no save exists or saved within 10s (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/emulator/emulator.component.ts
+++ b/maxhanna.client/src/app/emulator/emulator.component.ts
@@ -179,9 +179,9 @@ export class EmulatorComponent extends ChildComponent implements OnInit, OnDestr
       }
     }
 
-    // If we've saved recently (within 10s), skip asking the user again.
+    // Skip save confirm if last save was < 10s ago or no save has ever been made.
     const now = Date.now();
-    if (!this._saveInProgress && now - this._lastSaveTime < 10000) {
+    if (this._lastSaveTime === 0 || (!this._saveInProgress && now - this._lastSaveTime < 10000)) {
       if (this.stopEmuSaving || this.isExitingAndReturningToEmulator) {
         this.fullReloadToEmulator();
       } else {


### PR DESCRIPTION
## Summary
- In EmulatorComponent.safeExit(), the save confirmation dialog now skips when there has never been a save (_lastSaveTime === 0) or when the last save was within the last 10 seconds.
- Updated the comment to clarify the broader skip logic.

## Motivation
Previously, _lastSaveTime defaults to 