### PR TITLE
Add comments, reactions, topics, and polls to GetLatestMeme (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Controllers/FileController.cs
+++ b/maxhanna.Server/Controllers/FileController.cs
@@ -2047,6 +2047,24 @@ namespace maxhanna.Server.Controllers
                 User = new User(userId, username, displayPic, bgPic)
               };
 
+              var fileEntries = new List<FileEntry> { fileEntry };
+              List<int> fileIds;
+              List<int> commentIds = new List<int>();
+              List<string> fileIdsParameters;
+              GetIdsFromResults(fileEntries, out fileIds, out fileIdsParameters);
+              GetFileComments(fileEntries, connection, fileIds, commentIds, fileIdsParameters);
+
+              await FetchAndAttachPollVotesToFileComments(fileEntries);
+
+              var commentIdsParameters = new List<string>();
+              for (int i = 0; i < commentIds.Count; i++)
+              {
+                commentIdsParameters.Add($"@commentId{i}");
+              }
+
+              GetFileReactions(fileEntries, connection, fileIds, commentIds, fileIdsParameters, commentIdsParameters);
+              GetFileTopics(fileEntries, connection, fileIds);
+
               return Ok(fileEntry);
             }
             return NotFound("No memes found");


### PR DESCRIPTION
@Saint Added comment, reaction, topic, and poll fetching to GetLatestMeme to match the behavior of GetDirectory.

## What changed
- In GetLatestMeme, added calls to GetFileComments, FetchAndAttachPollVotesToFileComments, GetFileReactions, and GetFileTopics after constructing the FileEntry
- These use the same helper methods (GetIdsFromResults, GetFileComments, etc.) that GetDirectory uses, applied to a single-element List<FileEntry>

## Why
- GetLatestMeme was returning a FileEntry without its FileComments, reactions, topics, or poll data -- fields that GetDirectory always populates
- This was causing the client to miss comment counts and full comment threads when fetching the latest meme

## Implementation details
- Wraps the single ileEntry in a List<FileEntry> so the existing helper methods can populate all related data in-place
- The connection object is already open and reusable here, so no additional connection setup is needed