### PR TITLE
Add periodic polling to UserEvents component with proper cleanup (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/user-events/user-events.component.ts
+++ b/maxhanna.client/src/app/user-events/user-events.component.ts
@@ -17,14 +17,21 @@ export class UserEventsComponent extends ChildComponent implements OnInit, OnDes
   @Input() showTitleBar = true;
   @Output() hasData = new EventEmitter<boolean>();
   loading = false;
+  private pollingInterval: any;
 
   constructor(private userEventService: UserEventService) { super(); }
 
   async ngOnInit() {
     await this.loadEvents();
+    this.pollingInterval = setInterval(async () => {
+      await this.loadEvents();
+    }, 30000);
   }
   ngAfterViewInit() { }
   ngOnDestroy(): void {
+    if (this.pollingInterval) {
+      clearInterval(this.pollingInterval);
+    }
     this.remove_me("UserEventsComponent");
   }
   safeDestroy() {


### PR DESCRIPTION
:: What changes were made
- Added a pollingInterval property to user-events.component.ts
- In 
gOnInit, started polling for new user events every 30 seconds via setInterval that reuses the existing loadEvents() method
- In 
gOnDestroy, added clearInterval(this.pollingInterval) to properly clean up the interval when the component is destroyed

:: Why they were made
- The UserEvents component previously only loaded events once on initialization, meaning new events would not appear without a full page refresh
- The component implemented OnDestroy but had no cleanup for intervals/timers, which could lead to memory leaks or errors after the component is destroyed

:: Important implementation details
- Polling interval is set to 30 seconds, matching the pattern used by other polling components in the codebase (e.g., NotificationsComponent)
- The same loadEvents() method is reused for both initial load and polling, avoiding code duplication and ensuring consistent error handling
- The interval is safely checked for existence before clearing in 
gOnDestroy to prevent errors if destroy is called before init
- This PR was written using [Vibe Kanban](https://vibekanban.com)