### PR TITLE
Make story_post and comment events navigable (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/user-events/user-events.component.css
+++ b/maxhanna.client/src/app/user-events/user-events.component.css
@@ -16,6 +16,16 @@
     padding: 3px 0;
     font-size: 0.85rem;
     line-height: 1.3;
+    user-select: none;
+}
+.eventRow.clickable-event {
+    cursor: pointer;
+}
+.eventRow.clickable-event:hover {
+    opacity: 0.75;
+}
+.eventRow.non-clickable-event {
+    cursor: default;
 }
 .eventIcon { flex-shrink: 0; font-size: 0.9rem; }
 .eventText { flex: 1; word-break: break-word; }

--- a/maxhanna.client/src/app/user-events/user-events.component.html
+++ b/maxhanna.client/src/app/user-events/user-events.component.html
@@ -5,7 +5,7 @@
     <div *ngIf="loading" class="loading">Loading events...</div>
     <div *ngIf="loadError" class="error">{{ loadError }}</div>
     <div *ngIf="events && events.length > 0">
-      <div *ngFor="let e of events" class="eventRow">
+      <div *ngFor="let e of events" class="eventRow" [class.clickable-event]="isClickableEvent(e.eventType)" [class.non-clickable-event]="!isClickableEvent(e.eventType)" (click)="isClickableEvent(e.eventType) ? viewEvent(e) : null">
         <span class="eventIcon">{{ getEventIcon(e.eventType) }}</span>
         <span class="eventText">{{ e.eventText }}</span>
         <span class="eventTime" [title]="e.createdAt | date: 'y/MM/d HH:mm'">{{ e.createdAt | timeSince:'minute':true }}</span>

--- a/maxhanna.client/src/app/user-events/user-events.component.ts
+++ b/maxhanna.client/src/app/user-events/user-events.component.ts
@@ -3,6 +3,7 @@ import { ChildComponent } from '../child.component';
 import { UserEvent } from '../../services/datacontracts/user-event/user-event';
 import { UserEventService } from '../../services/user-event.service';
 import { AppComponent } from '../app.component';
+import { CommentService } from '../../services/comment.service';
 
 @Component({
   selector: 'app-user-events',
@@ -18,7 +19,7 @@ export class UserEventsComponent extends ChildComponent implements OnInit, OnDes
   @Output() hasData = new EventEmitter<boolean>();
   loading = false;
 
-  constructor(private userEventService: UserEventService) { super(); }
+  constructor(private userEventService: UserEventService, private commentService: CommentService) { super(); }
 
   async ngOnInit() {
     await this.loadEvents();
@@ -65,5 +66,29 @@ export class UserEventsComponent extends ChildComponent implements OnInit, OnDes
       case 'trophy': return '🏆';
       default: return '📌';
     }
+  }
+
+  viewEvent(e: UserEvent) {
+    if (e.referenceId == null) return;
+    if (e.eventType === 'story_post') {
+      this.parentRef?.createComponent('Social', { 'storyId': e.referenceId });
+    } else if (e.eventType === 'comment') {
+      this.viewComment(e);
+    }
+  }
+
+  async viewComment(e: UserEvent) {
+    const comment = await this.commentService.getCommentById(e.referenceId);
+    if (comment && comment.storyId) {
+      this.parentRef?.createComponent('Social', { 'storyId': comment.storyId, 'commentId': comment.id });
+    } else if (comment && comment.fileId) {
+      this.parentRef?.createComponent('Files', { 'fileId': comment.fileId.toString() });
+    } else {
+      this.parentRef?.showNotification('Could not find the original post or file for this comment.');
+    }
+  }
+
+  isClickableEvent(eventType: string): boolean {
+    return eventType === 'story_post' || eventType === 'comment';
   }
 }


### PR DESCRIPTION
## Summary

Adds clickable navigation to `story_post` and `comment` events in the User-Events activity feed, so users can jump directly to the referenced social post or comment from their activity history.

## Changes

### `user-events.component.ts`
- Injected `CommentService` to resolve comment details on demand
- Added `viewEvent(event)`: routes `story_post` events to the Social component with the story ID, and `comment` events to `viewComment()`
- Added `viewComment()`: fetches the comment via `CommentService.getCommentById()`, then navigates to:
  - `Social` component with the comment's `storyId` and `commentId` (if the comment belongs to a story), so the comment is highlighted in context
  - `Files` component (if the comment belongs to a file)
  - Shows a notification if the original could not be found
- Added `isClickableEvent()`: returns true for `story_post` and `comment` event types

### `user-events.component.html`
- Added conditional class bindings (`clickable-event` / `non-clickable-event`) to each event row in `*ngFor`
- Added `(click)` handler that invokes `viewEvent()` only for clickable event types

### `user-events.component.css`
- `.eventRow.clickable-event`: adds pointer cursor
- `.eventRow.clickable-event:hover`: adds 0.75 opacity on hover for visual feedback
- `.eventRow.non-clickable-event`: keeps default cursor for non-navigable events

## Why

Previously, the activity feed was purely informational - clicking any event row did nothing. Users had no way to jump to a referenced story or comment from their activity log, making it frustrating to navigate to content of interest.

## Implementation Notes

- **Comment resolution**: For `comment` events, the actual `storyId` is not stored in the `UserEvent` model. We fetch the comment via `CommentService.getCommentById(referenceId)` and extract its `storyId`. This ensures the user lands on the correct story with the comment highlighted.
- **Files fallback**: Comments that belong to files (not stories) navigate to the `Files` component instead.
- **No referenceId guard**: Events with a null `referenceId` are safely no-ops.
- **Parent ref**: Uses existing `parentRef.createComponent()` and `parentRef.showNotification()` patterns - consistent with the rest of the codebase.

This PR was written using [Vibe Kanban](https://vibekanban.com)
