### PR TITLE
Add date range slider to news section in globe data panel (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/globe/globe.component.css
+++ b/maxhanna.client/src/app/globe/globe.component.css
@@ -263,6 +263,31 @@
   margin-bottom: 4px;
 }
 
+.news-filters {
+  padding: 0 0 12px;
+  border-bottom: 1px solid #3a3a5a;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.news-filters label {
+  color: #aaa;
+  font-size: 12px;
+}
+
+.news-date-slider {
+  width: 100%;
+  accent-color: #e8a838;
+}
+
+.news-date-label {
+  color: #e8a838;
+  font-size: 12px;
+  text-align: right;
+}
+
 .news-meta {
   color: #777;
   font-size: 11px;

--- a/maxhanna.client/src/app/globe/globe.component.html
+++ b/maxhanna.client/src/app/globe/globe.component.html
@@ -57,14 +57,20 @@
     </div>
 
     <div class="data-content" *ngIf="activeDataTab === 'news'">
+      <div class="news-filters">
+        <label>Filter by date:</label>
+        <input type="range" min="0" max="100" [value]="newsDateFilterValue"
+               (input)="onNewsDateFilter($event)" class="news-date-slider">
+        <span class="news-date-label">{{ newsDateFilterLabel }}</span>
+      </div>
       <div class="news-list">
-        <div class="news-item" *ngFor="let pin of newsPins" (click)="onNewsPinClick(pin); showDataPanel = false">
+        <div class="news-item" *ngFor="let pin of filteredNewsPins" (click)="onNewsPinClick(pin); showDataPanel = false">
           <div class="news-title">{{ pin.articleTitle }}</div>
           <div class="news-description">{{ pin.description || 'No description' }}</div>
-          <div class="news-meta">{{ pin.label }} · {{ pin.locationType }}</div>
+          <div class="news-meta">{{ pin.label }} · {{ pin.createdAt?.toDateString() || 'No date' }}</div>
         </div>
-        <div class="no-news" *ngIf="newsPins.length === 0">
-          No news articles with locations available.
+        <div class="no-news" *ngIf="filteredNewsPins.length === 0">
+          No news articles match the selected date range.
         </div>
       </div>
     </div>

--- a/maxhanna.client/src/app/globe/globe.component.ts
+++ b/maxhanna.client/src/app/globe/globe.component.ts
@@ -178,6 +178,10 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   // ---- story pins ---------------------------------------------------------
   private stories: Story[] = [];
   newsPins: NewsPin[] = [];
+  filteredNewsPins: NewsPin[] = [];
+  minNewsDate: Date | null = null;
+  maxNewsDate: Date | null = null;
+  newsDateFilterValue: number = 100;
   private customPings: GlobePing[] = [];
   private hoveredPin: { id: string; label: string; x: number; y: number } | null = null;
   private activePingId: string | null = null;
@@ -562,6 +566,14 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   private async loadNewsPins(): Promise<void> {
     try {
       this.newsPins = await this.newsService.getNewsPins();
+      const dates = this.newsPins
+        .map(p => p.createdAt).filter((d): d is Date => !!d)
+        .sort((a, b) => a.getTime() - b.getTime());
+      if (dates.length) {
+        this.minNewsDate = dates[0];
+        this.maxNewsDate = dates[dates.length - 1];
+      }
+      this.applyNewsDateFilter();
     } catch { /* non-fatal */ }
   }
 
@@ -592,6 +604,29 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
       this.maxDate.getTime() - totalDays * (this.dateFilterValue / 100) * 86400000
     );
     this.filteredStories = this.stories.filter(s => !s.date || s.date >= cutoff);
+  }
+
+  get newsDateFilterLabel(): string {
+    if (!this.minNewsDate || !this.maxNewsDate) return 'All time';
+    const totalMs = this.maxNewsDate.getTime() - this.minNewsDate.getTime();
+    const days = Math.ceil(totalMs / 86400000);
+    const filtered = Math.floor(days * (this.newsDateFilterValue / 100));
+    const start = new Date(this.maxNewsDate.getTime() - filtered * 86400000);
+    return `${start.toLocaleDateString()} - ${this.maxNewsDate.toLocaleDateString()}`;
+  }
+
+  onNewsDateFilter(event: Event): void {
+    this.newsDateFilterValue = parseInt((event.target as HTMLInputElement).value, 10);
+    this.applyNewsDateFilter();
+  }
+
+  private applyNewsDateFilter(): void {
+    if (!this.minNewsDate || !this.maxNewsDate) { this.filteredNewsPins = this.newsPins; return; }
+    const totalDays = (this.maxNewsDate.getTime() - this.minNewsDate.getTime()) / 86400000;
+    const cutoff = new Date(
+      this.maxNewsDate.getTime() - totalDays * (this.newsDateFilterValue / 100) * 86400000
+    );
+    this.filteredNewsPins = this.newsPins.filter(p => !p.createdAt || p.createdAt >= cutoff);
   }
 
   onStoryClick(story: Story): void {
@@ -665,7 +700,7 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
     const storyPings = this.filteredStories
       .map(story => this.storyToPing(story))
       .filter((ping): ping is ResolvedGlobePing => !!ping);
-    const newsPings = this.newsPins
+    const newsPings = this.filteredNewsPins
       .map(pin => this.newsPinToPing(pin))
       .filter((ping): ping is ResolvedGlobePing => !!ping);
     const customPings = this.customPings


### PR DESCRIPTION
## Summary

Added a date range slider to the News tab in the globe data panel, matching the existing pattern used in the Stories tab.

## Changes

### TypeScript (globe.component.ts)
- Added `filteredNewsPins`, `minNewsDate`, `maxNewsDate`, and `newsDateFilterValue` properties to track the date-filtered subset of news pins
- Added `newsDateFilterLabel` getter that displays the active date range (e.g. "05/04/2026 - 05/14/2026")
- Added `onNewsDateFilter()` event handler and `applyNewsDateFilter()` method that compute a cutoff date and filter pins whose `createdAt` is on or after it
- Updated `getAllPings()` to use `filteredNewsPins` instead of the full `newsPins` array, so the slider controls which pins appear as pings on the globe
- During `loadNewsPins()`, min/max dates are computed from all available news pin `createdAt` values to set the slider range automatically

### HTML (globe.component.html)
- Added a range input slider (0-100) above the news list with the filter label
- News list now iterates over `filteredNewsPins` instead of `newsPins`
- Each news item meta now displays **location + published date** (e.g. "New York, USA, 05/08/2026") instead of "location + locationType"

### CSS (globe.component.css)
- Added `.news-filters`, `.news-date-slider`, and `.news-date-label` styles with amber accent color

## How it Works

1. On load, all news pins are fetched and their `createdAt` dates determine the full slider range
2. The slider defaults to 100 (showing all pins in the full range)
3. Moving the slider to a lower value shows only pins from the most recent N% of the date range
4. Filtered pins update both the pings on the globe and the news list in the data panel

> This PR was written using [Vibe Kanban](https://vibekanban.com)
