### PR TITLE
log trade execution as user_event in KrakenService (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Services/KrakenService.cs
+++ b/maxhanna.Server/Services/KrakenService.cs
@@ -1,4 +1,5 @@
-﻿using FirebaseAdmin.Messaging;
+using FirebaseAdmin.Messaging;
+using maxhanna.Server.Controllers;
 using maxhanna.Server.Controllers.DataContracts.Crypto;
 using Microsoft.AspNetCore.Mvc;
 using MySqlConnector;
@@ -2174,6 +2175,13 @@ public class KrakenService
         }
 
         await SendTradeNotification(currentCoinPriceInUSDC, amount, userId, from, to, strategy, conn);
+
+        string buyOrSell = to == "USDC" ? "Sell" : "Buy";
+        decimal tradeValue = Convert.ToDecimal(amount) * currentCoinPriceInUSDC;
+        string eventText = buyOrSell == "Buy"
+          ? $"Bought {amount} {to}"
+          : $"Sold {amount} {from}";
+        await UserEventController.InsertUserEventStatic(userId, null, "trade_executed", eventText, newId, "trade_history", _config, _log);
       }
       else
       {


### PR DESCRIPTION
--- KrakenService.cs:2 - Added using maxhanna.Server.Controllers; to import UserEventController.

--- KrakenService.cs:2179-2184 - In CreateTradeHistory, after a successful trade insert, added a call to UserEventController.InsertUserEventStatic to log the trade:

- **EventType**: 	rade_executed
- **EventText**: Bought {amount} {to} for buys or Sold {amount} {from} for sells
- **ReferenceId**: The new trade history ID
- **ReferenceType**: 	rade_history

## Why

Trading is now tracked in the user_events feed alongside other in-game activities (story_post, favourite_add, digcraft_play, etc.) so users can see their trading history in the unified event timeline.

## Notes

- The user_event entry is created after the trade is committed to 	rade_history, using the static insertion method since KrakenService doesn't have a UserEventController dependency.
- username is passed as 
ull since KrakenService doesn't resolve usernames internally.
- Errors in user_event insertion are silently caught by InsertUserEventStatic, matching the pattern used across the codebase.