### PR TITLE
Add pin visibility toggles for each globe data panel section (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/globe/globe.component.css
+++ b/maxhanna.client/src/app/globe/globe.component.css
@@ -756,3 +756,58 @@
     width: calc(100vw - 50px);
   }
 }
+
+/* Pin Toggle Switch */
+.pin-toggle-row {
+  padding: 0 0 12px;
+  border-bottom: 1px solid #3a3a5a;
+  margin-bottom: 12px;
+}
+
+.pin-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+}
+
+.pin-toggle-label {
+  color: #aaa;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.pin-toggle input {
+  display: none;
+}
+
+.pin-toggle-slider {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  background: #3a3a5a;
+  border-radius: 11px;
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+
+.pin-toggle-slider::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.pin-toggle input:checked + .pin-toggle-slider {
+  background: #4af;
+}
+
+.pin-toggle input:checked + .pin-toggle-slider::before {
+  transform: translateX(18px);
+}

--- a/maxhanna.client/src/app/globe/globe.component.html
+++ b/maxhanna.client/src/app/globe/globe.component.html
@@ -33,6 +33,13 @@
     </div>
 
     <div class="data-content" *ngIf="activeDataTab === 'stories'">
+      <div class="pin-toggle-row">
+        <label class="pin-toggle">
+          <span class="pin-toggle-label">Show Stories Pins</span>
+          <input type="checkbox" [checked]="showStoriesPins" (change)="showStoriesPins = $any($event.target).checked">
+          <span class="pin-toggle-slider"></span>
+        </label>
+      </div>
       <div class="ping-actions">
         <button type="button" (click)="focusNextPing()">Next ping</button>
         <button type="button" (click)="startPingTour()">Tour</button>
@@ -57,6 +64,13 @@
     </div>
 
     <div class="data-content" *ngIf="activeDataTab === 'news'">
+      <div class="pin-toggle-row">
+        <label class="pin-toggle">
+          <span class="pin-toggle-label">Show News Pins</span>
+          <input type="checkbox" [checked]="showNewsPins" (change)="showNewsPins = $any($event.target).checked">
+          <span class="pin-toggle-slider"></span>
+        </label>
+      </div>
       <div class="news-filters">
         <label>Filter by date:</label>
         <input type="range" min="0" max="100" [value]="newsDateFilterValue"
@@ -76,6 +90,13 @@
     </div>
 
     <div class="data-content" *ngIf="activeDataTab === 'flights'">
+      <div class="pin-toggle-row">
+        <label class="pin-toggle">
+          <span class="pin-toggle-label">Show Flight Pins</span>
+          <input type="checkbox" [checked]="showFlightsPins" (change)="showFlightsPins = $any($event.target).checked">
+          <span class="pin-toggle-slider"></span>
+        </label>
+      </div>
       <div class="flights-content">
         <div class="add-flight-form">
           <div class="form-title">Track Flight</div>
@@ -109,6 +130,13 @@
     </div>
 
     <div class="data-content" *ngIf="activeDataTab === 'users'">
+      <div class="pin-toggle-row">
+        <label class="pin-toggle">
+          <span class="pin-toggle-label">Show Users Pins</span>
+          <input type="checkbox" [checked]="showUsersPins" (change)="showUsersPins = $any($event.target).checked">
+          <span class="pin-toggle-slider"></span>
+        </label>
+      </div>
       <div class="users-list">
         <div class="user-item" *ngFor="let user of usersWithLocations" (click)="onUserClick(user)">
           <div class="user-name">{{ user.username }}</div>

--- a/maxhanna.client/src/app/globe/globe.component.ts
+++ b/maxhanna.client/src/app/globe/globe.component.ts
@@ -1,4 +1,4 @@
-﻿import {
+import {
   Component, OnInit, OnDestroy, AfterViewInit,
   ElementRef, ViewChild, HostListener, NgZone,
   EventEmitter, Input, Output
@@ -208,7 +208,12 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   clusterLocationLabel = '';
   showUserPopup = false;
   selectedUser: UserWithLocation | null = null;
-  flightArcs: Arc[] = [];
+   flightArcs: Arc[] = [];
+  showStoriesPins = true;
+  showNewsPins = true;
+  showFlightsPins = true;
+  showUsersPins = true;
+
 
   // ---- coordinates display -------------------------------------------------
   coordsDisplay = '0.00°, 0.00°';
@@ -737,20 +742,20 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   private getAllPings(): ResolvedGlobePing[] {
-    const storyPings = this.filteredStories
+    const storyPings = this.showStoriesPins ? this.filteredStories
       .map(story => this.storyToPing(story))
-      .filter((ping): ping is ResolvedGlobePing => !!ping);
-    const newsPings = this.filteredNewsPins
+      .filter((ping): ping is ResolvedGlobePing => !!ping) : [];
+    const newsPings = this.showNewsPins ? this.filteredNewsPins
       .map(pin => this.newsPinToPing(pin))
-      .filter((ping): ping is ResolvedGlobePing => !!ping);
+      .filter((ping): ping is ResolvedGlobePing => !!ping) : [];
     const customPings = this.customPings
       .map((ping, index) => this.resolveCustomPing(ping, index))
       .filter((ping): ping is ResolvedGlobePing => !!ping);
-    const userPings = this.usersWithLocations
+    const userPings = this.showUsersPins ? this.usersWithLocations
       .map(user => this.userToPing(user))
-      .filter((ping): ping is ResolvedGlobePing => !!ping);
+      .filter((ping): ping is ResolvedGlobePing => !!ping) : [];
 
-    const flightPings = this.getFlightPings();
+    const flightPings = this.showFlightsPins ? this.getFlightPings() : [];
     return [...storyPings, ...newsPings, ...customPings, ...userPings, ...flightPings];
   }
 


### PR DESCRIPTION
This PR adds pin visibility toggles to each section of the globe's data panel.\n\n## Changes Made\n- Added 4 boolean toggle variables (showStoriesPins, showNewsPins, showFlightsPins, showUsersPins) to control visibility of pins for each data category\n- Updated getAllPings() method to filter pins based on these toggles\n- Added toggle switches in the data panel UI for each tab section (Stories, News, Flights, Users)\n- Implemented iOS-style CSS styling for the toggle switches\n\n## Why These Changes Were Made\nThe task requested that each section in the globe's data panel should have a toggler to show/remove pins on the globe. When a user clicks on a data button to open the panel, and then clicks on any tab, they should see a toggler for that specific tab's pins.\n\n## Implementation Details\n- Toggles default to 'on' (showing pins) for backward compatibility\n- When toggled off, only pins for that specific category are hidden from the globe display\n- UI includes clear labels and visual feedback for toggle state\n\nThis PR was written using [Vibe Kanban](https://vibekanban.com)