### PR TITLE
Fix archer arrows stopping on player and reduce skeleton arrow frequency (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/digcraft/digcraft.component.ts
+++ b/maxhanna.client/src/app/digcraft/digcraft.component.ts
@@ -1814,7 +1814,9 @@ export class DigCraftComponent extends ChildComponent implements OnInit, OnDestr
 
           // Shoot arrow at player periodically
           if (dist <= bowRange && dist >= minRange) {
-            if (!mob.lastArrow || (now - mob.lastArrow) >= 1800) {
+            // Reduce arrow frequency for both Skeleton and Archer to match backend simulation
+            const arrowCooldown = mob.type === 'Archer' ? 2000 : 2500; // 2s for archer, 2.5s for skeleton
+            if (!mob.lastArrow || (now - mob.lastArrow) >= arrowCooldown) {
               mob.lastArrow = now;
               // Fire arrow toward player
               const arrowSpeed = 2.5;
@@ -5235,6 +5237,24 @@ export class DigCraftComponent extends ChildComponent implements OnInit, OnDestr
           vz: (Math.random() - 0.5) * 0.2,
           life: 0, maxLife: 0.4 + Math.random() * 0.3
         });
+      }
+
+      // Check for player collision before terrain collision
+      const player = this.otherPlayers.find(p => p.userId === this.currentUser.id);
+      if (player) {
+        const dx = arrow.wx - player.posX;
+        const dy = arrow.wy - player.posY;
+        const dz = arrow.wz - player.posZ;
+        const distSq = dx * dx + dy * dy + dz * dz;
+        // Player collision radius (smaller than player hitbox)
+        const playerCollisionRadius = 0.7;
+        if (distSq < playerCollisionRadius * playerCollisionRadius) {
+          // Stick arrow in player hitbox
+          (arrow as any).stuck = true;
+          (arrow as any).stickX = player.posX;
+          (arrow as any).stickY = player.posY;
+          (arrow as any).stickZ = player.posZ;
+        }
       }
 
       // Terrain collision: check if arrow is inside a solid block


### PR DESCRIPTION
## Summary

This PR addresses two issues with mob arrows in DigCraft:

1. **Archer arrows going beyond player**: Fixed arrow collision detection so arrows now properly stop when hitting the player instead of continuing past them
2. **Skeleton arrow frequency**: Reduced arrow shooting frequency for both skeletons and archers to better match backend simulation rates

## Changes Made

- Modified digcraft.component.ts to add player collision detection in the updateArrows() function
- Adjusted arrow shooting cooldown times for archers (2s) and skeletons (2.5s) to align with backend behavior
- These changes ensure consistent arrow behavior between frontend and backend

## Why These Changes Were Made

The frontend was showing archer arrows going past players and skeletons shooting arrows too frequently compared to what the backend was simulating, causing inconsistent damage per second and gameplay imbalance.

## Implementation Details

- Added player hitbox detection before terrain collision in arrow update logic
- Reduced arrow cooldowns to 2000ms for archers and 2500ms for skeletons
- Maintains server-authoritative damage calculation while improving frontend visualization

This PR was written using [Vibe Kanban](https://vibekanban.com)