### PR TITLE
In the comments component, theres a "Breadcrumb" of names you can click on to go up the comment (vibe-kanban)

### DIFF
--- a/maxhanna.client/src/app/comments/comments.component.css
+++ b/maxhanna.client/src/app/comments/comments.component.css
@@ -315,6 +315,37 @@
   margin-bottom: 15px;
 }
 
+.breadcrumb-full-path {
+  padding: 10px 16px;
+  margin-bottom: 15px;
+  background-color: rgba(0, 0, 0, 0.05);
+  border-radius: 4px;
+}
+
+.breadcrumb-comment-snippet {
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.breadcrumb-comment-snippet:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.breadcrumb-comment-user {
+  font-weight: bold;
+  margin-bottom: 4px;
+  color: var(--main-font-color);
+}
+
+.breadcrumb-comment-text {
+  color: var(--secondary-font-color);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
 .commentAvatarAndDate {
   display: inline-flex;
   align-items: center;

--- a/maxhanna.client/src/app/comments/comments.component.html
+++ b/maxhanna.client/src/app/comments/comments.component.html
@@ -24,8 +24,11 @@
     </span>
   </span>
 </div>
-<div class="breadcrumb-parent-snippet thirdFontColor xxSmallFont" *ngIf="getActiveBreadcrumbSnippet()">
-  — {{ getActiveBreadcrumbSnippet() }}
+<div class="breadcrumb-full-path" *ngIf="breadcrumbComments.length > 0">
+  <div class="breadcrumb-comment-snippet" *ngFor="let comment of breadcrumbComments; let i = index">
+    <div class="breadcrumb-comment-user">{{ comment.user.username }}:</div>
+    <div class="breadcrumb-comment-text">{{ (comment.commentText || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim() | slice:0:140 }}{{ (comment.commentText || '').replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim().length > 140 ? '...' : '' }}</div>
+  </div>
 </div>
 
 <div 

--- a/maxhanna.client/src/app/comments/comments.component.ts
+++ b/maxhanna.client/src/app/comments/comments.component.ts
@@ -115,17 +115,7 @@ export class CommentsComponent extends ChildComponent implements OnInit, AfterVi
     } catch { }
   }
 
-  getActiveBreadcrumbSnippet(maxLength: number = 140): string {
-    if (!this.breadcrumbComments || !this.breadcrumbComments.length) return '';
-    const parent = this.breadcrumbComments[this.breadcrumbComments.length - 1];
-    if (!parent || !parent.commentText) return '';
-    let txt = parent.user.username + ': ' + parent.commentText.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
-    if (!txt) return '';
-    if (txt.length > maxLength) {
-      txt = txt.slice(0, maxLength - 1) + '…';
-    }
-    return txt;
-  }
+ 
 
   private findCommentPath(targetId: number, list: FileComment[]): FileComment[] | null {
     for (const c of list) {


### PR DESCRIPTION
tree, theres also the "last comment" on display above the place where it shows the subcomments for that comment. I want the "last comment" area to actually contain all the previous comments that led to this subset, so people can see the comment tree entirely