### PR TITLE
Create UserEvents for all DigCraft player death scenarios (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Controllers/DigCraftController.cs
+++ b/maxhanna.Server/Controllers/DigCraftController.cs
@@ -3858,6 +3858,19 @@ var mobSpeed = t switch
 
                 if (affected == 0) return BadRequest("Player not found");
 
+                string? username = null;
+                using (var nameCmd = new MySqlCommand("SELECT username FROM maxhanna.users WHERE id = @uid LIMIT 1", conn))
+                {
+                    nameCmd.Parameters.AddWithValue("@uid", req.UserId);
+                    var result = await nameCmd.ExecuteScalarAsync();
+                    username = result?.ToString();
+                }
+
+                await UserEventController.InsertUserEventWithConnection(
+                    req.UserId, username, "digcraft_death",
+                    $"Died in DigCraft!",
+                    null, null, conn);
+
                 return Ok(new { ok = true, message = "Player killed" });
             }
             catch (Exception ex)
@@ -4621,6 +4634,32 @@ var mobSpeed = t switch
 
                     // Grant EXP to attacker
                     await GrantExpToPlayerAsync(req.AttackerUserId, req.WorldId, 25);
+
+                    string? attackerUsername = null;
+                    using (var nameCmd = new MySqlCommand("SELECT username FROM maxhanna.users WHERE id = @uid LIMIT 1", conn))
+                    {
+                        nameCmd.Parameters.AddWithValue("@uid", req.AttackerUserId);
+                        var result = await nameCmd.ExecuteScalarAsync();
+                        attackerUsername = result?.ToString();
+                    }
+
+                    string? victimUsername = null;
+                    using (var nameCmd = new MySqlCommand("SELECT username FROM maxhanna.users WHERE id = @uid LIMIT 1", conn))
+                    {
+                        nameCmd.Parameters.AddWithValue("@uid", req.TargetUserId);
+                        var result = await nameCmd.ExecuteScalarAsync();
+                        victimUsername = result?.ToString();
+                    }
+
+                    await UserEventController.InsertUserEventWithConnection(
+                        req.AttackerUserId, attackerUsername, "digcraft_kill",
+                        $"Killed {victimUsername ?? "a player"} in DigCraft!",
+                        targetDbId, "digcraft_player", conn);
+
+                    await UserEventController.InsertUserEventWithConnection(
+                        req.TargetUserId, victimUsername, "digcraft_death",
+                        $"Killed by {attackerUsername ?? "a player"} in DigCraft!",
+                        req.AttackerUserId, "digcraft_player", conn);
                 }
 
                 return Ok(new { ok = true, damage = finalDamage, targetUserId = req.TargetUserId, health = newHealth });
@@ -4710,6 +4749,19 @@ var mobSpeed = t switch
                     resetExpCmd.Parameters.AddWithValue("@uid", req.UserId);
                     resetExpCmd.Parameters.AddWithValue("@wid", req.WorldId);
                     await resetExpCmd.ExecuteNonQueryAsync();
+
+                    string? username = null;
+                    using (var nameCmd = new MySqlCommand("SELECT username FROM maxhanna.users WHERE id = @uid LIMIT 1", conn))
+                    {
+                        nameCmd.Parameters.AddWithValue("@uid", req.UserId);
+                        var result = await nameCmd.ExecuteScalarAsync();
+                        username = result?.ToString();
+                    }
+
+                    await UserEventController.InsertUserEventWithConnection(
+                        req.UserId, username, "digcraft_death",
+                        $"Died from fall damage in DigCraft!",
+                        null, null, conn);
                 }
 
                 return Ok(new { ok = true, damage = reducedDamage, health = newHealth });
@@ -4829,6 +4881,19 @@ var mobSpeed = t switch
                     resetExpCmd.Parameters.AddWithValue("@uid", req.UserId);
                     resetExpCmd.Parameters.AddWithValue("@wid", req.WorldId);
                     await resetExpCmd.ExecuteNonQueryAsync();
+
+                    string? username = null;
+                    using (var nameCmd = new MySqlCommand("SELECT username FROM maxhanna.users WHERE id = @uid LIMIT 1", conn))
+                    {
+                        nameCmd.Parameters.AddWithValue("@uid", req.UserId);
+                        var result = await nameCmd.ExecuteScalarAsync();
+                        username = result?.ToString();
+                    }
+
+                    await UserEventController.InsertUserEventWithConnection(
+                        req.UserId, username, "digcraft_death",
+                        $"Killed by {req.MobType} in DigCraft!",
+                        null, null, conn);
                 }
 
                 return Ok(new { ok = true, damage = reducedDamage, health = newHealth });


### PR DESCRIPTION
﻿## Summary

Adds UserEvent creation to every death path in DigCraft (Attack, FallDamage, MobAttack, KillPlayer), so player deaths are logged in the user_events table — just like the existing kill/death events in Ender and Bones.

## Changes Made

- **POST /digcraft/attack (PvP)** — Creates a digcraft_kill event for the attacker and a digcraft_death event for the victim, each referencing the other party's user ID.
- **POST /digcraft/fall (fall damage)** — Creates a digcraft_death event with the text "Died from fall damage in DigCraft!".
- **POST /digcraft/mobattack (mob damage)** — Creates a digcraft_death event with the text "Killed by {mobType} in DigCraft!".
- **POST /digcraft/killplayer (manual kill)** — Creates a digcraft_death event with the text "Died in DigCraft!".

## Implementation Details

- Each event uses the existing UserEventController.InsertUserEventWithConnection method, which includes 5-second deduplication protection.
- Usernames are fetched from the users table via the same pattern already used in CheckLevelUpAsync.
- Follows the same convention as ender_kill/ender_death and ones_kill/ones_death event types.
- No schema changes — only new INSERT calls to the existing user_events table.

This PR was written using [Vibe Kanban](https://vibekanban.com)
