### PR TITLE
Fix null reference warnings in backend to ensure clean compilation (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Controllers/CommentController.cs
+++ b/maxhanna.Server/Controllers/CommentController.cs
@@ -466,7 +466,7 @@ namespace maxhanna.Server.Controllers
 										IsFavourited = reader.IsDBNull(reader.GetOrdinal("commentFileEntryIsFavourited")) ? false : reader.GetBoolean("commentFileEntryIsFavourited"),
                                     };
 
-                                    if (!comment.CommentFiles.Any(f => f.Id == fileEntry.Id))
+                                    if (comment.CommentFiles != null && !comment.CommentFiles.Any(f => f.Id == fileEntry.Id))
                                     {
                                         comment.CommentFiles.Add(fileEntry);
                                     }
@@ -510,7 +510,7 @@ namespace maxhanna.Server.Controllers
                                         };
                                     }
 
-                                    if (!comment.Reactions.Any(r => r.Id == reaction.Id))
+                                    if (comment.Reactions != null && !comment.Reactions.Any(r => r.Id == reaction.Id))
                                     {
                                         comment.Reactions.Add(reaction);
                                     }


### PR DESCRIPTION
## Summary

This PR addresses null reference warnings that were occurring in the backend compilation process. The changes ensure proper null checking before calling methods on potentially null collections.

## Changes Made

- Fixed two warnings in CommentController.cs related to potential null reference arguments
- Added null checks before calling .Any() method on comment.CommentFiles and comment.Reactions collections
- These changes prevent the compiler from issuing warnings about possible null reference arguments

## Why This Was Done

The backend was compiling successfully but had two warnings related to potential null references when calling the .Any() LINQ method. While these weren't preventing compilation, they represented code quality issues that could be improved.

## Implementation Details

The fix involved adding explicit null checks before calling the .Any() method:
- comment.CommentFiles != null && !comment.CommentFiles.Any(f => f.Id == fileEntry.Id)
- comment.Reactions != null && !comment.Reactions.Any(r => r.Id == reaction.Id)

This ensures defensive programming practices while maintaining all existing functionality.

This PR was written using [Vibe Kanban](https://vibekanban.com)