### PR TITLE
Override CSS font sizes for user-events component when showTitleBar is false (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/user-events/user-events.component.css
+++ b/maxhanna.client/src/app/user-events/user-events.component.css
@@ -61,6 +61,20 @@
   margin-left: auto;
 }
 
+/* When showTitleBar is false, override font sizes to normal */
+.user-events-component:not(.componentMain) .userEventsTitle,
+.user-events-component:not(.componentMain) .eventRow,
+.user-events-component:not(.componentMain) .eventText,
+.user-events-component:not(.componentMain) .eventTime,
+.user-events-component:not(.componentMain) .popupPanelTitle {
+  font-size: 1rem !important;
+  line-height: 1.4;
+}
+
+.user-events-component:not(.componentMain) .eventIcon {
+  font-size: 1rem !important;
+}
+
 /* Popup Panel Styles */
 .popupPanelOverlay {
   position: fixed;


### PR DESCRIPTION
This PR addresses the requirement to show text with normal font sizes instead of large/xx-large when showTitleBar is false in the user-events component.

Changes made:
- Modified the CSS in user-events.component.css to include conditional styling
- Added CSS rules that target elements when the component doesn't have the 'componentMain' class (when showTitleBar is false)
- These rules override font sizes to normal sizes (1rem) instead of large/xx-large
- Used !important to ensure these styles take precedence over other font size declarations

The implementation ensures that when showTitleBar is set to false, all text elements in the list display with normal font sizes, improving readability and consistency in the UI.

This PR was written using [Vibe Kanban](https://vibekanban.com)