### PR TITLE
Fix mobile globe pull-to-refresh and zoom mode issues (Vibe Kanban)

### DIFF
--- a/maxhanna.client/src/app/globe/globe.component.ts
+++ b/maxhanna.client/src/app/globe/globe.component.ts
@@ -1890,17 +1890,31 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
   private bindTouchEvents(): void {
     const gc = this.globeCanvasRef.nativeElement;
     let lastDist = 0;
+    let isZooming = false; // Track if we're in zoom mode
+    
+    // Prevent pull-to-refresh on mobile
+    gc.addEventListener('touchstart', (e) => {
+      // Check if the touch started on the globe canvas
+      if (e.target === gc) {
+        // Prevent default behavior for touchstart on canvas to prevent pull-to-refresh
+        e.preventDefault();
+      }
+    }, { passive: false });
+    
     gc.addEventListener('touchstart', e => {
       if (e.touches.length === 1) {
         this.isDragging = true;
         this.lastX = e.touches[0].clientX;
         this.lastY = e.touches[0].clientY;
+        isZooming = false; // Reset zoom state
       } else if (e.touches.length === 2) {
         lastDist = this.touchDist(e);
+        isZooming = true; // Set zoom mode
       }
     }, { passive: true });
+    
     gc.addEventListener('touchmove', e => {
-      if (e.touches.length === 1 && this.isDragging) {
+      if (e.touches.length === 1 && this.isDragging && !isZooming) {
         const dx = e.touches[0].clientX - this.lastX;
         const dy = e.touches[0].clientY - this.lastY;
         this.lastX = e.touches[0].clientX;
@@ -1915,7 +1929,11 @@ export class GlobeComponent implements OnInit, AfterViewInit, OnDestroy {
         this.syncSliderFromDist();
       }
     }, { passive: true });
-    gc.addEventListener('touchend', () => { this.isDragging = false; }, { passive: true });
+    
+    gc.addEventListener('touchend', () => { 
+      this.isDragging = false;
+      isZooming = false; // Reset zoom state when touch ends
+    }, { passive: true });
   }
 
   private touchDist(e: TouchEvent): number {


### PR DESCRIPTION
This PR addresses two mobile-specific issues in the globe component:

1. **Pull-to-refresh prevention**: Added touch event handling to prevent the browser's default pull-to-refresh behavior when interacting with the globe canvas on mobile devices. This resolves the issue where users would accidentally trigger page refreshes while trying to drag the globe.

2. **Zoom mode bug fix**: Implemented proper tracking of zoom state to ensure that after zooming with two fingers, the globe correctly returns to normal dragging mode for subsequent interactions. Previously, the globe would remain in 'zoom mode' after zooming, causing dragging gestures to instead adjust the zoom level.

These changes improve the mobile user experience by making globe navigation more intuitive and preventing unwanted browser behaviors.

This PR was written using [Vibe Kanban](https://vibekanban.com)