### PR TITLE
Ejs restart button is not the right way to restart the emulatorjs emulator (as if the user presses (vibe-kanban)

### DIFF
--- a/maxhanna.client/src/assets/n64wasm/index.html
+++ b/maxhanna.client/src/assets/n64wasm/index.html
@@ -238,7 +238,7 @@
                         Options
                     </button>
                     <div class="dropdown-menu">
-                        <a class="dropdown-item" onclick="myApp.reset()" style="cursor: pointer;">Reset</a>
+                        <a class="dropdown-item" onclick="myApp.softReset()" style="cursor: pointer;">Soft Reset</a>
                     </div>
                 </div>
                 <span rv-if="data.showDoubleSpeed">

--- a/maxhanna.client/src/assets/n64wasm/script.js
+++ b/maxhanna.client/src/assets/n64wasm/script.js
@@ -1611,6 +1611,16 @@ class MyClass {
         Module._neil_reset();
     }
 
+    softReset(){
+        // Call the ejs_softreset functionality
+        if (typeof Module !== 'undefined' && Module._neil_softreset) {
+            Module._neil_softreset();
+        } else {
+            // Fallback to regular reset if softreset is not available
+            this.reset();
+        }
+    }
+
     localCallback(){
     }
     


### PR DESCRIPTION
the reset button on the console, which would reset the console, load the game normally).. gotta use ejs\_softreset i think but how do we code it in?? Also, remove the ejs\_buttons reset button, its useless. Instead i want to have a new button in the menuPanel called "Soft Reset" that will fire the ejs\_softreset functionality. Figure out how to do it, dont do anything if it cant be done