### PR TITLE
Ban 'weightloss method' and 'diet method' keywords from news articles (Vibe Kanban)

### DIFF
--- a/maxhanna.Server/Services/NewsService.cs
+++ b/maxhanna.Server/Services/NewsService.cs
@@ -117,7 +117,7 @@ public class NewsService
   };
 
   // Words that should cause an article to be skipped entirely when indexing/saving
-  private static readonly string[] DirtyWords = new[] { "casino", "weight-loss", "free spins" };
+  private static readonly string[] DirtyWords = new[] { "casino", "weight-loss", "free spins", "weightloss method", "diet method" };
 
 
   // Negative sentiment keywords (expanded for financial & crypto-related negative events)


### PR DESCRIPTION
This PR adds 'weightloss method' and 'diet method' to the list of banned keywords in the news service.

Changes made:
- Added 'weightloss method' and 'diet method' to the DirtyWords array in NewsService.cs
- These keywords will now be filtered out during article import, preventing articles containing them from being saved to the database

The implementation leverages the existing filtering infrastructure that was already in place for banning other keywords like 'casino' and 'weight-loss', ensuring consistency with current code patterns.

This addresses the request to expand on the existing keyword filtering to exclude articles with these specific keywords.

This PR was written using [Vibe Kanban](https://vibekanban.com)